### PR TITLE
Add ability to approve a solution based on tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This module contains macros for a DSL to be able to compare ideal solution featu
   feature "has spec" do
 
     mentor_message "elixir.two_fer.no_specification"
-    severity :message # or :disapprove or :refer
+    severity :info # or :disapprove or :refer
     match :all # :any, :none, :one
     # status :test # :skip
 

--- a/lib/elixir_analyzer.ex
+++ b/lib/elixir_analyzer.ex
@@ -1,6 +1,7 @@
 defmodule ElixirAnalyzer do
   @moduledoc """
-  Documentation for ElixirAnalyzer.
+  Static analysis framework for Elixir using a domain specifc language and pattern
+  matching.
   """
 
   alias ElixirAnalyzer.Submission
@@ -12,7 +13,39 @@ defmodule ElixirAnalyzer do
   @output_file "analyze.json"
   @lib_dir "lib/"
 
-  # Entrypoint
+  @doc """
+  This is the main entry point to the analyzer.
+
+  ## Parameters
+
+  * `exercise` is which exercise is submitted to determine proper analysis
+
+  * `path` is the path (ending with a '/') to the submitted solution
+
+  * `opts` is a Keyword List of options, see **options**
+
+  ## Options
+
+  * `:exercise` - name of the exercise, defaults to the `exercise` parameter
+
+  * `:path` - path to the submitted solution, defaults to the `path` parameter
+
+  * `:output_path` - path to write file output, defaults to the `path` parameter
+
+  * `:output_file`, - specificies the name of the output_file, defaults to
+    `@output_file` (`analyze.json`)
+
+  * `:exercise_config` - specifies the path to the JSON exercise configuration,
+    defaults to `@exercise_config` (`./config/exercise_data.json`)
+
+  * `:write_results` - boolean flag if an ananlysis should output the results to
+    JSON file, defaults to `true`
+
+  * `:puts_summary` - boolean flag if an ananlysis should print the summary of the
+    analysis to stdio, defaults to `true`
+
+  Any arbitrary keyword-value pair can be passed to `analyze_exercise/3` and these options may be used the other consuming code.
+  """
   @spec analyze_exercise(String.t(), String.t(), keyword()) :: Submission.t()
   def analyze_exercise(exercise, path, opts \\ []) do
     params = get_params(exercise, path, opts)
@@ -31,9 +64,9 @@ defmodule ElixirAnalyzer do
     s
   end
 
-  # translate arguments to a param map
+  # translate arguments to a param map, adding in defaults
   @spec get_params(String.t(), String.t(), Keyword.t()) :: map()
-  def get_params(exercise, path, opts \\ []) do
+  defp get_params(exercise, path, opts) do
     defaults = [
       {:exercise, exercise},
       {:path, path},

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -3,11 +3,21 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
 
   use ElixirAnalyzer.ExerciseTest
 
+  # these are all the tests need to pass for approval if no
+  # failing tests that trigger a disapproval, defaults to []
+  # if unspecified.
+  @tests_needed_to_approve [
+    "has default parameter",
+    "has guard",
+    "uses string interpolation",
+    "raises function clause error",
+  ]
+
   # has type specification
   feature "has spec" do
     # status :skip
     message("elixir.two_fer.no_specification")
-    severity(:message)
+    severity(:info)
     match(:all)
 
     form do
@@ -19,7 +29,7 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
   feature "has default parameter" do
     # status :skip
     message("elixir.two_fer.no_default_param")
-    severity(:message)
+    severity(:info)
     match(:all)
 
     form do
@@ -61,7 +71,7 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     end
   end
 
-  feature "use function clause error" do
+  feature "raises function clause error" do
     # status :skip
     message("elixir.two_fer.use_function_to_catch_bad_argument")
     severity(:disapprove)
@@ -75,7 +85,7 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
   feature "first level @moduledoc recomended" do
     # status :skip
     message("elixir.solution.missing_module_doc")
-    severity(:message)
+    severity(:info)
     match(:all)
     depth(1)
 

--- a/test/elixir_analyzer_test.exs
+++ b/test/elixir_analyzer_test.exs
@@ -12,7 +12,7 @@ defmodule ElixirAnalyzerTest do
       path = "./test_data/two_fer/passing_solution/"
       analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, @options)
       expected_output = """
-        {"comments":["elixir.general.refer_to_mentor"],"status":"refer_to_mentor"}
+        {"comments":["elixir.general.approve"],"status":"approve"}
         """
 
       assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)


### PR DESCRIPTION
This commit contains a few changes based on adding an ability of the analyzer to approve a solution.

- the DSL's feature attribute `severity` changed to `:info` from `:message` to reduce duplication of the word `message` since it was used to identify the unique markdown message to be displayed from `exercism/website-copy`
- better `@doc` written for elixir_analyzer.ex
- in `ElixirAnalyzer.ExerciseTest`, removed `failed_feature_test?/2` and expanded logic in `determine_status/3`
- in `ElixirAnalyzer.ExerciseTest.TwoFer` added an example how how to use the new feature
- ExUnit suite updated for new output

Close #4 