### PR TITLE
[Big PR] TwoFer Tests refined, ExerciseTest refactored/refined

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ This module contains macros for a DSL to be able to compare ideal solution featu
 
   # This is DSL for describing the test to be done
   # This describes that a solution should have a typespec for the two_fer function
-  feature "has spec" do
+  feature_test "has spec" do
 
-    mentor_message "elixir.two_fer.no_specification"
-    severity :info # or :disapprove or :refer
-    match :all # :any, :none, :one
-    # status :test # :skip
+    status   :test # :skip -- optional
+    find     :all # :any, :none, :one
+    on_fail  :info # or :disapprove or :refer
+    comment  Constants.two_fer_no_specification # may also be a string
 
     # the form of the code that you are looking for
     # you may include more than one form block
@@ -81,6 +81,10 @@ This module contains macros for a DSL to be able to compare ideal solution featu
     end
   end
 ```
+
+### `ElixirAnalyzer.Constants`
+
+Contains macro to generate a function returning the comment path on the `exercism/website-copy` repository.  The current plan is to centralize these so that they can be easily tested and changed
 
 ### `ElixirAnalyzer.CLI`
 
@@ -92,26 +96,10 @@ These modules are for describing the tests for which the analyzer is able to det
 
 ## Other Plans
 
-1. Develop the environment for execution (postponed)
-    * Edit, Aug 18/19 -- This will all be orchestrated in a docker container, so the code should be constrained (though absolute security is not possible in docker), if the need arises will come up with a solution.
+1. Develop the environment for execution (done)
 
-2. Finish the escript to be able to call the program from the command line with command line arguments
+2. Finish the escript to be able to call the program from the command line with command line arguments (done)
 
-3. Create the bash script to call the application with the parameters needed (stubbed in `bin/analyze.sh`)
+3. Create the bash script to call the application with the parameters needed (done)
 
-4. Create the Dockerfile in order to create the environment for the application to be run. (stubbed in `docker/Dockerfile`)
-
-## Dictionary of paramerized comments
-
-Parameterized Comment | Comment Description | Comment Website Copy
---------------------- | ------------------- | --------------------
-`"elixir.general.approve"` | Solution has been approved, may have more reasons to follow. |
-`"elixir.general.refer_to_mentor"` | Solution has been referred to a mentor, may have more reasons to follow. |
-`"elixir.general.disapprove"` | Solution has been disapproved for some reason, must have more reasons to follow. |
-`"elixir.general.code_file_not_found"` | Unable to locate the code file at the path |
-`"elixir.general.compile_success"` | Successful compile |
-`"elixir.general.compile_error"` | Some error occured with compilation |
---------------------- | ------------------- | --------------------
-`"elixir.analysis.quote_error"` | There was some error creating a quoted form (Abstract-Syntax-Tree) of the code as a string |
---------------------- | ------------------- | --------------------
-`"elixir.two_fer.no_specification"` | Suggest a type specification to student
+4. Create the Dockerfile in order to create the environment for the application to be run. (done)

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -18,6 +18,10 @@ defmodule ElixirAnalyzer.Constants do
     two_fer_use_default_parameter:    "elixir.two-fer.use_default_param",
     two_fer_use_guards:               "elixir.two-fer.use_guards",
     two_fer_use_string_interpolation: "elixir.two-fer.use_string_interpolation",
+    two_fer_wrong_specification:      "elixir.two-fer.wrong_specification",
+    two_fer_use_function_level_guard: "elixir.two_fer.use_function_level_guard",
+    two_fer_use_of_aux_functions:     "elixir.two_fer.use_of_aux_functions",
+    two_fer_use_of_function_header:   "elixir.two_fer.use_of_function_header"
   ]
 
   for {constant, markdown} <- @constants do

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -81,118 +81,42 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     end
   end
 
-  feature_test "has guard" do
+  feature_test "uses guards" do
     # status :skip
     find    :any
     on_fail :disapprove
     comment Constants.two_fer_use_guards
 
-    # is_binary cases
-    # acceptable
     form do
-      def two_fer(_ignore) when is_binary(_ignore), do: _ignore
-    end
-
-    # not acceptable, but will raise a different error
-    form do
-      case _ignore do
-        _ignore when is_binary(_ignore) -> _ignore
-        _ -> _ignore
-      end
+      is_binary(_ignore)
     end
 
     form do
-      case is_binary(_ignore) do
-        _ignore
-      end
-    end
-
-    form do
-      if is_binary(_ignore), do: _ignore
-    end
-
-    form do
-      if !is_binary(_ignore), do: _ignore
-    end
-
-    # is_bitstring cases
-    # acceptable
-    form do
-      def two_fer(_ignore) when is_bitstring(_ignore), do: _ignore
-    end
-
-    # not acceptable, but will raise a different error
-    form do
-      case _ignore do
-        _ignore when is_bitstring(_ignore) -> _ignore
-        _ -> _ignore
-      end
-    end
-
-    form do
-      case is_bitstring(_ignore) do
-        _ignore
-      end
-    end
-
-    form do
-      if is_bitstring(_ignore), do: _ignore
-    end
-
-    form do
-      if !is_bitstring(_ignore), do: _ignore
+      is_bitstring(_ignore)
     end
   end
 
-  feature_test "use function level guard" do
-    # status   :skip
-    find        :none
-    on_fail    :disapprove
-    suppress_if "has guard", :fail
+  feature_test "uses function level guard" do
+    # status      :skip
+    find        :any
+    on_fail     :refer
+    suppress_if "uses guards", :fail
     comment     Constants.two_fer_use_function_level_guard
 
-    # is_binary cases
     form do
-      case _ignore do
-        _ignore when is_binary(_ignore) -> _ignore
-        _ -> _ignore
-      end
+      def two_fer(_ignore \\ "you") when is_binary(_ignore), _ignore
     end
 
     form do
-      case is_binary(_ignore) do
-        _ignore
-      end
+      def two_fer(_ignore) when is_binary(_ignore), _ignore
     end
 
     form do
-      if is_binary(_ignore), do: _ignore
+      def two_fer(_ignore \\ "you") when is_bitstring(_ignore), _ignore
     end
 
     form do
-      if !is_binary(_ignore), do: _ignore
-    end
-
-    # is_bitstring cases
-    form do
-      case _ignore do
-        _ignore when is_bitstring(_ignore) -> _ignore
-        _ -> _ignore
-      end
-    end
-
-    form do
-      case is_bitstring(_ignore) do
-        _ignore
-      end
-    end
-
-    form do
-      if is_bitstring(_ignore), do: _ignore
-    end
-
-    form do
-      if !is_bitstring(_ignore), do: _ignore
+      def two_fer(_ignore) when is_bitstring(_ignore), _ignore
     end
   end
 

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -8,37 +8,37 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
   @auto_approvable true
 
   #
-  # Two-fer features
+  # Two-fer feature_tests
   #
 
-  feature "has spec" do
+  feature_test "has spec" do
     # status :skip
-    message  Constants.solution_use_specification
-    severity :info
-    match    :all
+    find     :all
+    on_fail  :info
+    comment  Constants.solution_use_specification
 
     form do
       @spec _ignore
     end
   end
 
-  feature "has wrong spec" do
+  feature_test "has wrong spec" do
     # status      :skip
-    message     Constants.two_fer_wrong_specification
-    severity    :refer
-    match       :all
+    find        :all
+    on_fail     :refer
     suppress_if "has spec", :fail
+    comment     Constants.two_fer_wrong_specification
 
     form do
       @spec two_fer(String.t()) :: String.t()
     end
   end
 
-  feature "has default parameter" do
+  feature_test "has default parameter" do
     # status :skip
-    message  Constants.two_fer_use_default_parameter
-    severity :disapprove
-    match    :any
+    find    :any
+    on_fail :disapprove
+    comment Constants.two_fer_use_default_parameter
 
     # function header
     form do
@@ -70,22 +70,22 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     end
   end
 
-  feature "uses function header" do
+  feature_test "uses function header" do
     # status   :skip
-    message  Constants.two_fer_use_of_function_header
-    severity :refer
-    match    :none
+    find     :none
+    on_fail  :refer
+    comment  Constants.two_fer_use_of_function_header
 
     form do
       def two_fer(_ignore \\ "you")
     end
   end
 
-  feature "has guard" do
+  feature_test "has guard" do
     # status :skip
-    message  Constants.two_fer_use_guards
-    severity :disapprove
-    match    :any
+    find    :any
+    on_fail :disapprove
+    comment Constants.two_fer_use_guards
 
     # is_binary cases
     # acceptable
@@ -144,12 +144,12 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     end
   end
 
-  feature "use function level guard" do
+  feature_test "use function level guard" do
     # status   :skip
-    message     Constants.two_fer_use_function_level_guard
-    severity    :disapprove
-    match       :none
+    find        :none
+    on_fail    :disapprove
     suppress_if "has guard", :fail
+    comment     Constants.two_fer_use_function_level_guard
 
     # is_binary cases
     form do
@@ -196,45 +196,45 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     end
   end
 
-  feature "uses auxilary functions" do
+  feature_test "uses auxilary functions" do
     # status   :skip
-    message  Constants.two_fer_use_of_aux_functions
-    severity :refer
-    match    :none
+    find    :none
+    on_fail :refer
+    comment Constants.two_fer_use_of_aux_functions
 
     form do
       defp _ignore(_ignore), do: _ignore
     end
   end
 
-  feature "uses string interpolation" do
+  feature_test "uses string interpolation" do
     # status :skip
-    message  Constants.two_fer_use_string_interpolation
-    severity :disapprove
-    match    :any
+    find    :any
+    on_fail :disapprove
+    comment Constants.two_fer_use_string_interpolation
 
     form do
       "One for #{_ignore}, one for me"
     end
   end
 
-  feature "raises function clause error" do
+  feature_test "raises function clause error" do
     # status :skip
-    message  Constants.solution_raise_fn_clause_error
-    severity :disapprove
-    match    :none
+    find    :none
+    on_fail :disapprove
+    comment Constants.solution_raise_fn_clause_error
 
     form do
       raise FunctionClauseError
     end
   end
 
-  feature "first level @moduledoc recomended" do
+  feature_test "first level @moduledoc recomended" do
     # status :skip
-    message  Constants.solution_use_moduledoc
-    severity :info
-    match    :all
-    depth    1
+    find    :all
+    on_fail :info
+    comment Constants.solution_use_moduledoc
+    depth   1
 
     form do
       @moduledoc _ignore

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -27,7 +27,7 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     message     Constants.two_fer_wrong_specification
     severity    :refer
     match       :all
-    suppress_if :fail, "has spec"
+    suppress_if "has spec", :fail
 
     form do
       @spec two_fer(String.t()) :: String.t()
@@ -81,162 +81,163 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     end
   end
 
-  # feature "has guard" do
-  #   # status :skip
-  #   message  Constants.two_fer_use_guards
-  #   severity :disapprove
-  #   match    :any
+  feature "has guard" do
+    # status :skip
+    message  Constants.two_fer_use_guards
+    severity :disapprove
+    match    :any
 
-  #   # is_binary cases
-  #   # acceptable
-  #   form do
-  #     def two_fer(_ignore) when is_binary(_ignore), do: _ignore
-  #   end
+    # is_binary cases
+    # acceptable
+    form do
+      def two_fer(_ignore) when is_binary(_ignore), do: _ignore
+    end
 
-  #   # not acceptable, but will raise a different error
-  #   form do
-  #     case _ignore do
-  #       _ignore when is_binary(_ignore) -> _ignore
-  #       _ -> _ignore
-  #     end
-  #   end
+    # not acceptable, but will raise a different error
+    form do
+      case _ignore do
+        _ignore when is_binary(_ignore) -> _ignore
+        _ -> _ignore
+      end
+    end
 
-  #   form do
-  #     case is_binary(_ignore) do
-  #       _ignore
-  #     end
-  #   end
+    form do
+      case is_binary(_ignore) do
+        _ignore
+      end
+    end
 
-  #   form do
-  #     if is_binary(_ignore), do: _ignore
-  #   end
+    form do
+      if is_binary(_ignore), do: _ignore
+    end
 
-  #   form do
-  #     if !is_binary(_ignore), do: _ignore
-  #   end
+    form do
+      if !is_binary(_ignore), do: _ignore
+    end
 
-  #   # is_bitstring cases
-  #   # acceptable
-  #   form do
-  #     def two_fer(_ignore) when is_bitstring(_ignore), do: _ignore
-  #   end
+    # is_bitstring cases
+    # acceptable
+    form do
+      def two_fer(_ignore) when is_bitstring(_ignore), do: _ignore
+    end
 
-  #   # not acceptable, but will raise a different error
-  #   form do
-  #     case _ignore do
-  #       _ignore when is_bitstring(_ignore) -> _ignore
-  #       _ -> _ignore
-  #     end
-  #   end
+    # not acceptable, but will raise a different error
+    form do
+      case _ignore do
+        _ignore when is_bitstring(_ignore) -> _ignore
+        _ -> _ignore
+      end
+    end
 
-  #   form do
-  #     case is_bitstring(_ignore) do
-  #       _ignore
-  #     end
-  #   end
+    form do
+      case is_bitstring(_ignore) do
+        _ignore
+      end
+    end
 
-  #   form do
-  #     if is_bitstring(_ignore), do: _ignore
-  #   end
+    form do
+      if is_bitstring(_ignore), do: _ignore
+    end
 
-  #   form do
-  #     if !is_bitstring(_ignore), do: _ignore
-  #   end
-  # end
+    form do
+      if !is_bitstring(_ignore), do: _ignore
+    end
+  end
 
-  # feature "use function level guard" do
-  #   # status   :skip
-  #   message  Constants.two_fer_use_function_level_guard
-  #   severity :disapprove
-  #   match    :none
+  feature "use function level guard" do
+    # status   :skip
+    message     Constants.two_fer_use_function_level_guard
+    severity    :disapprove
+    match       :none
+    suppress_if "has guard", :fail
 
-  #   # is_binary cases
-  #   form do
-  #     case _ignore do
-  #       _ignore when is_binary(_ignore) -> _ignore
-  #       _ -> _ignore
-  #     end
-  #   end
+    # is_binary cases
+    form do
+      case _ignore do
+        _ignore when is_binary(_ignore) -> _ignore
+        _ -> _ignore
+      end
+    end
 
-  #   form do
-  #     case is_binary(_ignore) do
-  #       _ignore
-  #     end
-  #   end
+    form do
+      case is_binary(_ignore) do
+        _ignore
+      end
+    end
 
-  #   form do
-  #     if is_binary(_ignore), do: _ignore
-  #   end
+    form do
+      if is_binary(_ignore), do: _ignore
+    end
 
-  #   form do
-  #     if !is_binary(_ignore), do: _ignore
-  #   end
+    form do
+      if !is_binary(_ignore), do: _ignore
+    end
 
-  #   # is_bitstring cases
-  #   form do
-  #     case _ignore do
-  #       _ignore when is_bitstring(_ignore) -> _ignore
-  #       _ -> _ignore
-  #     end
-  #   end
+    # is_bitstring cases
+    form do
+      case _ignore do
+        _ignore when is_bitstring(_ignore) -> _ignore
+        _ -> _ignore
+      end
+    end
 
-  #   form do
-  #     case is_bitstring(_ignore) do
-  #       _ignore
-  #     end
-  #   end
+    form do
+      case is_bitstring(_ignore) do
+        _ignore
+      end
+    end
 
-  #   form do
-  #     if is_bitstring(_ignore), do: _ignore
-  #   end
+    form do
+      if is_bitstring(_ignore), do: _ignore
+    end
 
-  #   form do
-  #     if !is_bitstring(_ignore), do: _ignore
-  #   end
-  # end
+    form do
+      if !is_bitstring(_ignore), do: _ignore
+    end
+  end
 
-  # feature "uses auxilary functions" do
-  #   # status   :skip
-  #   message  Constants.two_fer_use_of_aux_functions
-  #   severity :refer
-  #   match    :all
+  feature "uses auxilary functions" do
+    # status   :skip
+    message  Constants.two_fer_use_of_aux_functions
+    severity :refer
+    match    :none
 
-  #   form do
-  #     defp _ignore(_ignore), do: _ignore
-  #   end
-  # end
+    form do
+      defp _ignore(_ignore), do: _ignore
+    end
+  end
 
-  # feature "uses string interpolation" do
-  #   # status :skip
-  #   message  Constants.two_fer_use_string_interpolation
-  #   severity :disapprove
-  #   match    :any
+  feature "uses string interpolation" do
+    # status :skip
+    message  Constants.two_fer_use_string_interpolation
+    severity :disapprove
+    match    :any
 
-  #   form do
-  #     "One for #{_ignore}, one for me"
-  #   end
-  # end
+    form do
+      "One for #{_ignore}, one for me"
+    end
+  end
 
-  # feature "raises function clause error" do
-  #   # status :skip
-  #   message  Constants.solution_raise_fn_clause_error
-  #   severity :disapprove
-  #   match    :none
+  feature "raises function clause error" do
+    # status :skip
+    message  Constants.solution_raise_fn_clause_error
+    severity :disapprove
+    match    :none
 
-  #   form do
-  #     raise FunctionClauseError
-  #   end
-  # end
+    form do
+      raise FunctionClauseError
+    end
+  end
 
-  # feature "first level @moduledoc recomended" do
-  #   # status :skip
-  #   message  Constants.solution_use_moduledoc
-  #   severity :info
-  #   match    :all
-  #   depth    1
+  feature "first level @moduledoc recomended" do
+    # status :skip
+    message  Constants.solution_use_moduledoc
+    severity :info
+    match    :all
+    depth    1
 
-  #   form do
-  #     @moduledoc _ignore
-  #   end
-  # end
+    form do
+      @moduledoc _ignore
+    end
+  end
 end

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -5,17 +5,12 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
 
   use ElixirAnalyzer.ExerciseTest
 
-  # these are all the tests need to pass for approval if no
-  # failing tests that trigger a disapproval, defaults to []
-  # if unspecified.
-  @tests_needed_to_approve [
-    "has default parameter",
-    "has guard",
-    "uses string interpolation",
-    "raises function clause error",
-  ]
+  @auto_approvable true
 
-  # has type specification
+  #
+  # Two-fer features
+  #
+
   feature "has spec" do
     # status :skip
     message  Constants.solution_use_specification
@@ -28,10 +23,11 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
   end
 
   feature "has wrong spec" do
-    status   :skip
-    message  Constants.two_fer_wrong_specification
-    severity :refer
-    match    :all
+    # status      :skip
+    message     Constants.two_fer_wrong_specification
+    severity    :refer
+    match       :all
+    suppress_if :fail, "has spec"
 
     form do
       @spec two_fer(String.t()) :: String.t()
@@ -75,136 +71,172 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
   end
 
   feature "uses function header" do
-    status   :skip
+    # status   :skip
     message  Constants.two_fer_use_of_function_header
     severity :refer
-    match    :any
+    match    :none
 
     form do
       def two_fer(_ignore \\ "you")
     end
   end
 
-  feature "has guard" do
-    # status :skip
-    message  Constants.two_fer_use_guards
-    severity :disapprove
-    match    :any
+  # feature "has guard" do
+  #   # status :skip
+  #   message  Constants.two_fer_use_guards
+  #   severity :disapprove
+  #   match    :any
 
-    # is_binary cases
-    form do
-      def two_fer(_ignore) when is_binary(_ignore), do: _ignore
-    end
+  #   # is_binary cases
+  #   # acceptable
+  #   form do
+  #     def two_fer(_ignore) when is_binary(_ignore), do: _ignore
+  #   end
 
-    form do
-      case _ignore do
-        _ignore when is_binary(_ignore) -> _ignore
-        _ -> _ignore
-      end
-    end
+  #   # not acceptable, but will raise a different error
+  #   form do
+  #     case _ignore do
+  #       _ignore when is_binary(_ignore) -> _ignore
+  #       _ -> _ignore
+  #     end
+  #   end
 
-    form do
-      case is_binary(_ignore) do
-        _ignore
-      end
-    end
+  #   form do
+  #     case is_binary(_ignore) do
+  #       _ignore
+  #     end
+  #   end
 
-    # is_bitstring cases
-    form do
-      def two_fer(_ignore) when is_bitstring(_ignore), do: _ignore
-    end
+  #   form do
+  #     if is_binary(_ignore), do: _ignore
+  #   end
 
-    form do
-      case _ignore do
-        _ignore when is_bitstring(_ignore) -> _ignore
-        _ -> _ignore
-      end
-    end
+  #   form do
+  #     if !is_binary(_ignore), do: _ignore
+  #   end
 
-    form do
-      case is_bitstring(_ignore) do
-        _ignore
-      end
-    end
-  end
+  #   # is_bitstring cases
+  #   # acceptable
+  #   form do
+  #     def two_fer(_ignore) when is_bitstring(_ignore), do: _ignore
+  #   end
 
-  feature "use function level guard" do
-    status   :skip
-    message  Constants.two_fer_use_function_level_guard
-    severity :disapprove
-    match    :any
+  #   # not acceptable, but will raise a different error
+  #   form do
+  #     case _ignore do
+  #       _ignore when is_bitstring(_ignore) -> _ignore
+  #       _ -> _ignore
+  #     end
+  #   end
 
-    # is_binary cases
-    form do
-      case _ignore do
-        _ignore when is_binary(_ignore) -> _ignore
-        _ -> _ignore
-      end
-    end
+  #   form do
+  #     case is_bitstring(_ignore) do
+  #       _ignore
+  #     end
+  #   end
 
-    form do
-      case is_binary(_ignore) do
-        _ignore
-      end
-    end
+  #   form do
+  #     if is_bitstring(_ignore), do: _ignore
+  #   end
 
-    # is_bitstring cases
-    form do
-      case _ignore do
-        _ignore when is_bitstring(_ignore) -> _ignore
-        _ -> _ignore
-      end
-    end
+  #   form do
+  #     if !is_bitstring(_ignore), do: _ignore
+  #   end
+  # end
 
-    form do
-      case is_bitstring(_ignore) do
-        _ignore
-      end
-    end
-  end
+  # feature "use function level guard" do
+  #   # status   :skip
+  #   message  Constants.two_fer_use_function_level_guard
+  #   severity :disapprove
+  #   match    :none
 
-  feature "uses auxilary functions" do
-    status   :skip
-    message  Constants.two_fer_use_of_aux_functions
-    severity :refer
-    match    :any
+  #   # is_binary cases
+  #   form do
+  #     case _ignore do
+  #       _ignore when is_binary(_ignore) -> _ignore
+  #       _ -> _ignore
+  #     end
+  #   end
 
-    form do
-      defp _ignore(_ignore), do: _ignore
-    end
-  end
+  #   form do
+  #     case is_binary(_ignore) do
+  #       _ignore
+  #     end
+  #   end
 
-  feature "uses string interpolation" do
-    # status :skip
-    message  Constants.two_fer_use_string_interpolation
-    severity :disapprove
-    match    :any
+  #   form do
+  #     if is_binary(_ignore), do: _ignore
+  #   end
 
-    form do
-      "One for #{_ignore}, one for me"
-    end
-  end
+  #   form do
+  #     if !is_binary(_ignore), do: _ignore
+  #   end
 
-  feature "raises function clause error" do
-    # status :skip
-    message  Constants.solution_raise_fn_clause_error
-    severity :disapprove
-    match    :none
+  #   # is_bitstring cases
+  #   form do
+  #     case _ignore do
+  #       _ignore when is_bitstring(_ignore) -> _ignore
+  #       _ -> _ignore
+  #     end
+  #   end
 
-    form do
-      raise FunctionClauseError
-    end
-  end
+  #   form do
+  #     case is_bitstring(_ignore) do
+  #       _ignore
+  #     end
+  #   end
 
-  feature "first level @moduledoc recomended" do
-    # status :skip
-    message  Constants.solution_use_moduledoc
-    severity :info
-    match    :all
-    depth    1
+  #   form do
+  #     if is_bitstring(_ignore), do: _ignore
+  #   end
 
-    form do
-      @moduledoc _ignore
-    end
-  end
+  #   form do
+  #     if !is_bitstring(_ignore), do: _ignore
+  #   end
+  # end
+
+  # feature "uses auxilary functions" do
+  #   # status   :skip
+  #   message  Constants.two_fer_use_of_aux_functions
+  #   severity :refer
+  #   match    :all
+
+  #   form do
+  #     defp _ignore(_ignore), do: _ignore
+  #   end
+  # end
+
+  # feature "uses string interpolation" do
+  #   # status :skip
+  #   message  Constants.two_fer_use_string_interpolation
+  #   severity :disapprove
+  #   match    :any
+
+  #   form do
+  #     "One for #{_ignore}, one for me"
+  #   end
+  # end
+
+  # feature "raises function clause error" do
+  #   # status :skip
+  #   message  Constants.solution_raise_fn_clause_error
+  #   severity :disapprove
+  #   match    :none
+
+  #   form do
+  #     raise FunctionClauseError
+  #   end
+  # end
+
+  # feature "first level @moduledoc recomended" do
+  #   # status :skip
+  #   message  Constants.solution_use_moduledoc
+  #   severity :info
+  #   match    :all
+  #   depth    1
+
+  #   form do
+  #     @moduledoc _ignore
+  #   end
+  # end
 end

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -12,6 +12,7 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     "has default parameter",
     "has guard",
     "uses string interpolation",
+    "raises function clause error",
   ]
 
   # has type specification
@@ -22,11 +23,21 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     match    :all
 
     form do
+      @spec _ignore
+    end
+  end
+
+  feature "has wrong spec" do
+    status   :skip
+    message  Constants.two_fer_wrong_specification
+    severity :refer
+    match    :all
+
+    form do
       @spec two_fer(String.t()) :: String.t()
     end
   end
 
-  # has function header with default parameter
   feature "has default parameter" do
     # status :skip
     message  Constants.two_fer_use_default_parameter
@@ -36,6 +47,18 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     # function header
     form do
       def two_fer(_ignore \\ "you")
+    end
+
+    # function without a guard
+    form do
+      def two_fer(_ignore \\ "you"), do: _ignore
+    end
+
+    # function without a guard and a do block
+    form do
+      def two_fer(_ignore \\ "you") do
+        _ignore
+      end
     end
 
     # function with do block
@@ -51,28 +74,106 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     end
   end
 
-  # function clauses use guards
+  feature "uses function header" do
+    status   :skip
+    message  Constants.two_fer_use_of_function_header
+    severity :refer
+    match    :any
+
+    form do
+      def two_fer(_ignore \\ "you")
+    end
+  end
+
   feature "has guard" do
     # status :skip
     message  Constants.two_fer_use_guards
     severity :disapprove
     match    :any
 
+    # is_binary cases
     form do
       def two_fer(_ignore) when is_binary(_ignore), do: _ignore
     end
 
     form do
-      def two_fer(_ignore) do
-        case _ignore do
-          _ignore when is_binary(_ignore) -> _ignore
-          _ -> _ignore
-        end
+      case _ignore do
+        _ignore when is_binary(_ignore) -> _ignore
+        _ -> _ignore
+      end
+    end
+
+    form do
+      case is_binary(_ignore) do
+        _ignore
+      end
+    end
+
+    # is_bitstring cases
+    form do
+      def two_fer(_ignore) when is_bitstring(_ignore), do: _ignore
+    end
+
+    form do
+      case _ignore do
+        _ignore when is_bitstring(_ignore) -> _ignore
+        _ -> _ignore
+      end
+    end
+
+    form do
+      case is_bitstring(_ignore) do
+        _ignore
       end
     end
   end
 
-  # string interpolation used
+  feature "use function level guard" do
+    status   :skip
+    message  Constants.two_fer_use_function_level_guard
+    severity :disapprove
+    match    :any
+
+    # is_binary cases
+    form do
+      case _ignore do
+        _ignore when is_binary(_ignore) -> _ignore
+        _ -> _ignore
+      end
+    end
+
+    form do
+      case is_binary(_ignore) do
+        _ignore
+      end
+    end
+
+    # is_bitstring cases
+    form do
+      case _ignore do
+        _ignore when is_bitstring(_ignore) -> _ignore
+        _ -> _ignore
+      end
+    end
+
+    form do
+      case is_bitstring(_ignore) do
+        _ignore
+      end
+    end
+  end
+
+  feature "uses auxilary functions" do
+    status   :skip
+    message  Constants.two_fer_use_of_aux_functions
+    severity :refer
+    match    :any
+
+    form do
+      defp _ignore(_ignore), do: _ignore
+    end
+  end
+
   feature "uses string interpolation" do
     # status :skip
     message  Constants.two_fer_use_string_interpolation
@@ -80,14 +181,14 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     match    :any
 
     form do
-      "One for #{name}, one for me"
+      "One for #{_ignore}, one for me"
     end
   end
 
   feature "raises function clause error" do
     # status :skip
     message  Constants.solution_raise_fn_clause_error
-    severity :info
+    severity :disapprove
     match    :none
 
     form do

--- a/test/elixir_analyzer_constants_test.exs
+++ b/test/elixir_analyzer_constants_test.exs
@@ -13,7 +13,7 @@ defmodule ElixirAnalyzerConstantsTest do
 
   describe "if comment exists at exercism/website-copy" do
     @comments Constants.list_of_all_comments()
-    @website_copy_url "https://github.com/exercism/website-copy/blob/master/"
+    @website_copy_url "https://github.com/exercism/website-copy/blob/master/automated-comments/"
     @file_ext ".md"
 
     for comment <- @comments do

--- a/test/elixir_analyzer_constants_test.exs
+++ b/test/elixir_analyzer_constants_test.exs
@@ -26,8 +26,7 @@ defmodule ElixirAnalyzerConstantsTest do
         {:ok, {{'HTTP/1.1', status, status_msg}, _headers, _body}} =
           :httpc.request(:head, {request_url, []}, [], [])
 
-        assert status == 200
-        assert status_msg == 'OK'
+        assert {status, status_msg, @comment} == {200, 'OK', @comment}
       end
     end
   end

--- a/test/elixir_analyzer_test.exs
+++ b/test/elixir_analyzer_test.exs
@@ -20,12 +20,12 @@ defmodule ElixirAnalyzerTest do
     end
 
     # @tag :pending
-    test "approved solution with comments" do
+    test "referred solution with comments" do
       exercise = "two-fer"
       path = "./test_data/two_fer/referred_solution/"
       analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, @options)
       expected_output = """
-        {\"comments\":[\"elixir.solution.use_module_doc\",\"elixir.solution.raise_fn_clause_error\",\"elixir.solution.use_specification\"],\"status\":\"approve\"}
+        {\"comments\":[\"elixir.solution.use_module_doc\",\"elixir.solution.raise_fn_clause_error\",\"elixir.two_fer.use_of_function_header\",\"elixir.solution.use_specification\"],\"status\":\"refer_to_mentor\"}
         """
 
       assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)

--- a/test_data/two_fer/referred_solution/lib/two_fer.ex
+++ b/test_data/two_fer/referred_solution/lib/two_fer.ex
@@ -2,7 +2,8 @@ defmodule TwoFer do
   @doc """
   Two-fer or 2-fer is short for two for one. One for you and one for me.
   """
-  def two_fer(name \\ "you") when is_binary(name) do
+  def two_fer(name \\ "you")
+  def two_fer(name) when is_binary(name) do
     "One for #{name}, one for me"
   end
   def two_fer(_name), do: raise FunctionClauseError


### PR DESCRIPTION
Pretext to changes:

I was able to obtain a large collection of two-fer submissions from @iHiD and subsequently ran the analyzer against them all, see [my test reesults repository](https://github.com/neenjaw/two-fer-test-data) (warning, it isn't really set up for much usable public consumption, but moreso as a record of the work).

Many changes were made in response to see how it fared against niche cases, erroring solutions, and odd constructs.

Working with the DSL, I also decided to change quite a few of the keywords to better suit the intent of the keyword so that it is more understandable how to interpret the test, and the result of the test.

---

Summary of the changes (from `git log`):

```
    Added some feature_tests:
    
    - added @spec feature
    - added bitstring guard
    - added default param, guard, wrong use of guard, aux func
    - added string interpolation and func header cases
```
```
    changes made to auto-approve, test clarified
```
```
    New DSL keywords added:
    
    - `suppress_if` allows tests to be silienced based on the status of other tests
```
```
   DSL changes:
    
    - `feature` is now `feature_test`
    - `:message` changed to `:comment` for congruity with exercism terminology
    - `:match` changed to `:find` for easier understanding the intent of the test
    - `:severity` changed to `:on_fail` to better represent
    
    Bugs Fixed:
    
    - suppressed results now filtered before they affect the submission determination
      - `filter_suppressed_results` created,
      - `append_test_comments`'s suppression code removed
```
```
    Guards simplified
    
    This test was first implemented when you couldn't suppress one test
    on another's result.  Now you can, so it makes it way easier to
    test for a specific pattern in the solution.
    
    So on the first pass, any appropriate guard is counted to pass the
    test "uses guards".  The second test "uses function level guard"
    then looks for the guard which is wanted in the optimal solution.
    
    Some README.md updates to refect current structure.
```