### PR TITLE
Towards gaining better engagement: 01 - Create a method for teaching module tests

### DIFF
--- a/bin/analyze.sh
+++ b/bin/analyze.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./elixir_analyzer --exercise "$1" --path "$2"
+./elixir_analyzer "$1" "$2"

--- a/lib/elixir_analyzer/cli.ex
+++ b/lib/elixir_analyzer/cli.ex
@@ -1,12 +1,18 @@
 defmodule ElixirAnalyzer.CLI do
   @usage """
-  $ elixir_analyzer <exercise-name> <path> [options]
+  Usage:
 
-  You may also pass the following optional flags:
+    $ elixir_analyzer <exercise-name> <path> [options]
+
+  You may also pass the following options:
     --skip-analysis                       flag skips running the static analysis
     --output <path>                       where to print the output, default to path
     --output-file <filename>
-    --analyze-file <full-path>:<module-name>
+
+  You may also test only individual files :
+    (assuming analyzer tests are compiled for the named module)
+
+    $ exercism_analyzer --analyze-file <full-path-to-.ex>:<module-name>
   """
 
   @options [

--- a/lib/elixir_analyzer/cli.ex
+++ b/lib/elixir_analyzer/cli.ex
@@ -3,16 +3,17 @@ defmodule ElixirAnalyzer.CLI do
   $ elixir_analyzer <exercise-name> <path> [options]
 
   You may also pass the following optional flags:
-    --skip-analysis           flag skips running the static analysis
-    --output path, -o path    where to print the output, default to path
-    --output-file filename, -f filename
+    --skip-analysis                       flag skips running the static analysis
+    --output <path>                       where to print the output, default to path
+    --output-file <filename>
+    --analyze-file <full-path>:<module-name>
   """
 
   @options [
     {{:skip_analyze, :boolean}, false},
     {{:output_dir, :string}, nil},
     {{:output_file, :string}, "analyze.json"},
-    {{:single_file, :boolean}, false},
+    {{:analyze_file, :string}, nil},
     {{:help, :boolean}, false}
   ]
 
@@ -20,8 +21,6 @@ defmodule ElixirAnalyzer.CLI do
   def main(args) do
     args |> parse_args() |> process()
   end
-
-  def parse_args(args) when length(args) < 2, do: :help
 
   def parse_args(args) do
     options = %{
@@ -34,9 +33,15 @@ defmodule ElixirAnalyzer.CLI do
       )
 
     case cmd_opts do
-      {[help: true], _, _}        -> :help
-      {opts, [exercise, path], _} -> {Enum.into(opts, options), exercise, path}
-      _                           -> :help
+      {[help: true], _, _}           -> :help
+
+      {[analyze_file: target], _, _} ->
+        [path, module] = String.split(target, ":", trim: true)
+        {Enum.into([module: module], options), "undefined", path}
+
+      {opts, [exercise, path], _}    -> {Enum.into(opts, options), exercise, path}
+
+      _                              -> :help
     end
   end
 

--- a/lib/elixir_analyzer/cli.ex
+++ b/lib/elixir_analyzer/cli.ex
@@ -1,6 +1,6 @@
 defmodule ElixirAnalyzer.CLI do
   @usage """
-  $ elixir_analyzer {--exercise exercise-name|exercise-name} {--path path-to|path-to}
+  $ elixir_analyzer <exercise-name> <path> [options]
 
   You may also pass the following optional flags:
     --skip-analysis           flag skips running the static analysis
@@ -10,52 +10,46 @@ defmodule ElixirAnalyzer.CLI do
 
   @options [
     {{:skip_analyze, :boolean}, false},
-    {{:exercise, :string}, nil},
-    {{:path, :string}, nil},
-    {{:output, :string}, nil},
-    {{:output_file, :string}, "analyze.json"}
+    {{:output_dir, :string}, nil},
+    {{:output_file, :string}, "analyze.json"},
+    {{:single_file, :boolean}, false},
+    {{:help, :boolean}, false}
   ]
 
-  @spec main() :: no_return
   @spec main(list(String.t())) :: no_return
-  def main(args \\ []) do
-    {options, argv, _} =
+  def main(args) do
+    args |> parse_args() |> process()
+  end
+
+  def parse_args(args) when length(args) < 2, do: :help
+
+  def parse_args(args) do
+    options = %{
+      :output_file => "analyze.json"
+    }
+
+    cmd_opts =
       OptionParser.parse(args,
-        alias: [
-          o: :output,
-          f: :output_file
-        ],
-        strict: for({option, _default} <- @options, do: option)
+        strict: (for {o, _} <- @options, do: o)
       )
 
-    exercise = Keyword.get(options, :exercise, false)
-    path = Keyword.get(options, :path, false)
-
-    {exercise, path, err} =
-      case {exercise, path, argv} do
-        {false, false, argv} when length(argv) >= 2 ->
-          {Enum.at(argv, 0), Enum.at(argv, 1), false}
-
-        {_, false, argv} when length(argv) >= 1 ->
-          {exercise, Enum.at(argv, 0), false}
-
-        {false, _, argv} when length(argv) >= 1 ->
-          {Enum.at(argv, 0), path, false}
-
-        _ ->
-          {nil, nil, true}
-      end
-
-    if err do
-      IO.puts(@usage)
-    else
-      opts =
-        for {{option, _type}, default} <- @options,
-            value = Keyword.get(options, option, default),
-            value != nil,
-            do: {option, value}
-
-      ElixirAnalyzer.analyze_exercise(exercise, path, opts)
+    case cmd_opts do
+      {[help: true], _, _}        -> :help
+      {opts, [exercise, path], _} -> {Enum.into(opts, options), exercise, path}
+      _                           -> :help
     end
+  end
+
+  def process(:help), do: IO.puts(@usage)
+
+  def process({options, exercise, path}) do
+    opts =
+      @options
+      |> Enum.reduce(options, fn {{o, _}, d}, acc ->
+        Map.put_new(acc, o, d)
+      end)
+      |> Map.to_list()
+
+    ElixirAnalyzer.analyze_exercise(exercise, path, opts)
   end
 end

--- a/lib/elixir_analyzer/cli.ex
+++ b/lib/elixir_analyzer/cli.ex
@@ -36,8 +36,10 @@ defmodule ElixirAnalyzer.CLI do
       {[help: true], _, _}           -> :help
 
       {[analyze_file: target], _, _} ->
-        [path, module] = String.split(target, ":", trim: true)
-        {Enum.into([module: module], options), "undefined", path}
+        [fullpath, module] = String.split(target, ":", trim: true)
+        path = Path.dirname(fullpath)
+        file = Path.basename(fullpath)
+        {Enum.into([module: module, file: file], options), "undefined", path}
 
       {opts, [exercise, path], _}    -> {Enum.into(opts, options), exercise, path}
 

--- a/lib/elixir_analyzer/exercise_test/example.ex
+++ b/lib/elixir_analyzer/exercise_test/example.ex
@@ -1,0 +1,8 @@
+defmodule ElixirAnalyzer.ExerciseTest.Example do
+  alias ElixirAnalyzer.Constants
+
+  use ElixirAnalyzer.ExerciseTest
+
+  @auto_approvable true
+
+end

--- a/lib/elixir_analyzer/exercise_test/example.ex
+++ b/lib/elixir_analyzer/exercise_test/example.ex
@@ -1,8 +1,0 @@
-defmodule ElixirAnalyzer.ExerciseTest.Example do
-  alias ElixirAnalyzer.Constants
-
-  use ElixirAnalyzer.ExerciseTest
-
-  @auto_approvable true
-
-end

--- a/lib/elixir_analyzer/summary.ex
+++ b/lib/elixir_analyzer/summary.ex
@@ -14,7 +14,7 @@ defmodule ElixirAnalyzer.Summary do
     #{params.exercise} analysis ... #{result_to_string(:halted, s)}!
 
     Analysis ... #{result_to_string(:analyzed, s)}
-    Output written to ... #{params.path}#{params.output_file}
+    Output written to ... #{params.path}/#{params.output_file}
     """
   end
 


### PR DESCRIPTION
Before this series of commits, the analyzer required a person to run it on a complete mix-project.  This poses a bit of a challenge then with creating a structure to teach a person how to write module analyzers.  

### Goal of the series of commits:

- Redo to the CLI interface
  - allow testing of individual files
  - remove irrelevant options
  - better usage help
- Change `ElixirAnalyzer` module to allow testing of individual files
  - decouple the mix-project style from the path
  
### Summary of file changes:

#### bin/analyze.sh

- change to new CLI interface with positional arguments

#### lib/elixir_analyzer.sh

- decouple path from mix-projects to allow for individual file tests
- standardardize the way paths are used, with no trailing slash

#### lib/elixir_analyzer/cli.ex

- CLI code re-written for better maintainability, now using the strict option parser rather than the switch style

#### lib/elixir_analyzer/summary.ex

- fixed out paths were printed to stdout