### PR TITLE
Unit test exercise tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ erl_crash.dump
 ex_mentor-*.tar
 
 # the escript
-elixir_analyzer
-bin/elixir_analyzer
+/elixir_analyzer
+/bin/elixir_analyzer
 
 #but not elixir_analyzer source
 !lib/elixir_analyzer/

--- a/docs/step-03/step-03.md
+++ b/docs/step-03/step-03.md
@@ -134,6 +134,63 @@ defmodule ElixirAnalyzer.ExerciseTest.Example do
 end
 ```
 
+##### 2.1 Limitations
+
+Slightly different syntax can produce exactly the same AST. That means that certain details cannot be distinguished by this analyzer. If they cannot be distinguished, they cannot be verified by the analyzer, but they also don't need to be both listed when specifying all of the forms for a feature.
+
+For example:  
+
+1. Single line vs multiline string
+    ```elixir
+    a =
+      quote do
+        """
+        1
+        2
+        """
+      end
+    
+    b = 
+      quote do
+        "1\n2\n"
+      end
+    
+    a == b
+    # => true
+    ```
+
+2. Single line vs multiline `do` blocks
+    ```elixir
+    a =
+      quote do
+        def foo do
+          "hello"
+        end
+      end
+    
+    b =
+      quote do
+        def foo, do: "hello"
+      end
+    
+    a == b
+    ```
+
+3. Usage of parenthesis in certain contexts
+    ```elixir
+    a =
+      quote do
+        def foo("hello")
+      end
+    
+    b =
+      quote do
+        def foo "hello"
+      end
+    
+    a == b
+    ```
+   
 #### 3. Add attributes to the matching process
 
 So far we have defined a feature to test, and a pattern to match, but we need to further specify how we want it to match and what it should do when it doesn't. We need to add the `find`, `on_fail`, and `comment` attributes:

--- a/docs/step-03/step-03.md
+++ b/docs/step-03/step-03.md
@@ -174,6 +174,7 @@ For example:
       end
     
     a == b
+    # => true
     ```
 
 3. Usage of parenthesis in certain contexts
@@ -189,6 +190,7 @@ For example:
       end
     
     a == b
+    # => true
     ```
    
 #### 3. Add attributes to the matching process

--- a/docs/step-03/step-03.md
+++ b/docs/step-03/step-03.md
@@ -288,7 +288,7 @@ So this next part will likely take a bit of testing to isolate the exact pattern
 4. determine if the analysis.json has to appropriate output
 5. (repeat)
 
-If you have made it this far, great! You are doing awesome. Now to learn about some of the other things we can do in a match in [step 4][step-4]
+If you have made it this far, great! You are doing awesome. Once you have a good idea about what kind of features you want the analyzer extension to look for, it's time for [step 4][step-4] - write unit tests for your new extension.
 
 [website-copy]: https://github.com/exercism/website-copy/tree/master/automated-comments
 [step-4]: ../step-04/step-04.md

--- a/docs/step-04/04-example-analysis-test.exs
+++ b/docs/step-04/04-example-analysis-test.exs
@@ -1,0 +1,17 @@
+defmodule ElixirAnalyzer.ExerciseTest.ExampleTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+      exercise_test_module: ElixirAnalyzer.ExerciseTest.Example
+
+  test_exercise_analysis "perfect solution",
+    status: :approve,
+    comments: [] do
+    defmodule Example do
+      @moduledoc """
+      Greets the user
+      """
+      def hello(name) do
+        "Hello, #{name}!"
+      end
+    end
+  end
+end

--- a/docs/step-04/step-04.md
+++ b/docs/step-04/step-04.md
@@ -1,0 +1,34 @@
+# A Guide to Writing an Elixir Analyzer Extension
+
+## Step 4: Adding unit tests for the new extension
+
+1. Create a new file in `/test/elixir_analyzer/exercise_test/` called `analyzer_extension_module_name_test.exs`.
+
+2. Do not use `ExUnit.Case` directly, but rather our custom `ElixirAnalyzer.ExerciseTestCase`. It takes the analyzer extension module as an option so that you don't need to repeat it with every test.
+    ```elixir
+    use ElixirAnalyzer.ExerciseTestCase,
+      exercise_test_module: ElixirAnalyzer.ExerciseTest.Example
+    ```
+
+3. Use the `test_exercise_analysis` macro to define test cases. It expects a test name, assertions about the analysis result status/comments, and a code snippet or list of code snippets in the `do` block. Refer to the macro's documentation for more details.
+
+    ```elixir
+    # 04-example-analysis-test.exs
+    defmodule ElixirAnalyzer.ExerciseTest.ExampleTest do
+      use ElixirAnalyzer.ExerciseTestCase,
+          exercise_test_module: ElixirAnalyzer.ExerciseTest.Example
+    
+      test_exercise_analysis "perfect solution",
+        status: :approve,
+        comments: [] do
+        defmodule Example do
+          @moduledoc """
+          Greets the user
+          """
+          def hello(name) do
+            "Hello, #{name}!"
+          end
+        end
+      end
+    end
+    ```

--- a/docs/writing-an-analyzer.md
+++ b/docs/writing-an-analyzer.md
@@ -3,9 +3,9 @@
 1. [Setting up the analyzer locally][step-1]
 2. [Anatomy of an extension][step-2]
 3. [Adding a feature test][step-3]
-4. [What else can we do with a test][step-4]
+4. [Adding unit tests for the new extension][step-4]
 
 [step-1]: ./step-01/step-01.md
 [step-2]: ./step-02/step-02.md
 [step-3]: ./step-03/step-03.md
-[step-4]: ../step-04/step-04.md
+[step-4]: ./step-04/step-04.md

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -133,15 +133,16 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
       defp _ignore(_ignore), do: _ignore
     end
 
-    form do
-      def two_fer(_ignore), do: _ignore
-      def _ignore(_ignore), do: _ignore
-    end
-
-    form do
-      def _ignore(_ignore), do: _ignore
-      def two_fer(_ignore), do: _ignore
-    end
+    #    # how to match functions named anything _but_ two_fer?
+    #    form do
+    #      def two_fer(_ignore), do: _ignore
+    #      def _ignore(_ignore), do: _ignore
+    #    end
+    #
+    #    form do
+    #      def _ignore(_ignore), do: _ignore
+    #      def two_fer(_ignore), do: _ignore
+    #    end
   end
 
   feature "uses string interpolation" do

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -122,17 +122,6 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     form do
       defp _ignore(_ignore), do: _ignore
     end
-
-    #    # how to match functions named anything _but_ two_fer?
-    #    form do
-    #      def two_fer(_ignore), do: _ignore
-    #      def _ignore(_ignore), do: _ignore
-    #    end
-    #
-    #    form do
-    #      def _ignore(_ignore), do: _ignore
-    #      def two_fer(_ignore), do: _ignore
-    #    end
   end
 
   feature "uses string interpolation" do

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -132,6 +132,16 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
     form do
       defp _ignore(_ignore), do: _ignore
     end
+
+    form do
+      def two_fer(_ignore), do: _ignore
+      def _ignore(_ignore), do: _ignore
+    end
+
+    form do
+      def _ignore(_ignore), do: _ignore
+      def two_fer(_ignore), do: _ignore
+    end
   end
 
   feature "uses string interpolation" do

--- a/lib/elixir_analyzer/exercise_test/two_fer.ex
+++ b/lib/elixir_analyzer/exercise_test/two_fer.ex
@@ -48,12 +48,7 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
       def two_fer(_ignore \\ "you")
     end
 
-    # function without a guard
-    form do
-      def two_fer(_ignore \\ "you"), do: _ignore
-    end
-
-    # function without a guard and a do block
+    # function without a guard and with a do block
     form do
       def two_fer(_ignore \\ "you") do
         _ignore
@@ -65,11 +60,6 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFer do
       def two_fer(_ignore \\ "you") when _ignore do
         _ignore
       end
-    end
-
-    # function one-liner
-    form do
-      def two_fer(_ignore \\ "you") when _ignore, do: _ignore
     end
   end
 

--- a/test/elixir_analyzer/constants_test.exs
+++ b/test/elixir_analyzer/constants_test.exs
@@ -1,4 +1,4 @@
-defmodule ElixirAnalyzerConstantsTest do
+defmodule ElixirAnalyzer.ConstantsTest do
   use ExUnit.Case
   doctest ElixirAnalyzer
 

--- a/test/elixir_analyzer/exercise_test/two_fer_test.exs
+++ b/test/elixir_analyzer/exercise_test/two_fer_test.exs
@@ -27,26 +27,221 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
     end
   end
 
-  test_exercise_analysis "correct spec",
-    comments_exclude: [Constants.two_fer_wrong_specification()] do
-    defmodule TwoFer do
-      @spec two_fer(String.t()) :: String.t()
-      def two_fer(name)
+  describe "spec" do
+    test_exercise_analysis "correct spec",
+      comments_exclude: [
+        Constants.solution_use_specification(),
+        Constants.two_fer_wrong_specification()
+      ] do
+      defmodule TwoFer do
+        @spec two_fer(String.t()) :: String.t()
+        def two_fer(name)
+      end
+    end
+
+    test_exercise_analysis "refer when wrong spec",
+      status: :refer,
+      comments_include: [Constants.two_fer_wrong_specification()] do
+      [
+        defmodule TwoFer do
+          @spec two_fer(binary()) :: binary()
+          def two_fer(name)
+        end,
+        defmodule TwoFer do
+          @spec two_fer(bitstring()) :: bitstring()
+          def two_fer(name)
+        end
+      ]
+    end
+
+    test_exercise_analysis "info when missing spec",
+      status: :approve,
+      comments_include: [Constants.solution_use_specification()] do
+      defmodule TwoFer do
+        @moduledoc """
+        Two-fer or 2-fer is short for two for one. One for you and one for me.
+        """
+        def two_fer(name \\ "you") when is_binary(name) do
+          "One for #{name}, one for me"
+        end
+      end
     end
   end
 
-  test_exercise_analysis "wrong spec",
-    status: :refer,
-    comments_include: [Constants.two_fer_wrong_specification()] do
-    [
-      defmodule TwoFer do
-        @spec two_fer(binary()) :: binary()
-        def two_fer(name)
-      end,
-      defmodule TwoFer do
-        @spec two_fer(bitstring()) :: bitstring()
-        def two_fer(name)
-      end
-    ]
+  describe "default parameter" do
+    test_exercise_analysis "finds the default parameter",
+      comments_exclude: [Constants.two_fer_use_default_parameter()] do
+      [
+        defmodule TwoFer do
+          def two_fer(x \\ "you")
+        end,
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            "One for #{name}, one for me"
+          end
+        end
+      ]
+    end
+
+    test_exercise_analysis "disapprove when not using a default parameter",
+      status: :disapprove,
+      comments_include: [Constants.two_fer_use_default_parameter()] do
+      [
+        defmodule TwoFer do
+          def two_fer(_)
+        end,
+        defmodule TwoFer do
+          def two_fer(name \\ "wrong default value")
+        end,
+        defmodule TwoFer do
+          def two_fer(name) do
+            "One for #{name}, one for me"
+          end
+        end,
+        defmodule TwoFer do
+          def two_fer(name), do: "One for #{name}, one for me"
+        end,
+        defmodule TwoFer do
+          def two_fer(name) when is_binary(name) do
+            "One for #{name}, one for me"
+          end
+        end,
+        defmodule TwoFer do
+          def two_fer(name) when is_binary(name), do: "One for #{name}, one for me"
+        end
+      ]
+    end
   end
+
+  #  describe "function header" do
+  #    test_exercise_analysis "refer when using a function header",
+  #      status: :refer,
+  #      comments_include: [Constants.two_fer_use_of_function_header()] do
+  #      defmodule TwoFer do
+  #        def two_fer(name \\ "you") when is_binary(name)
+  #      end
+  #    end
+  #  end
+
+  describe "guards" do
+    test_exercise_analysis "usage of is_binary or is_bitstring is required",
+      status: :disapprove,
+      comments_include: [Constants.two_fer_use_guards()] do
+      defmodule TwoFer do
+        def two_fer(name \\ "you") do
+          "One for #{name}, one for me"
+        end
+      end
+    end
+
+    test_exercise_analysis "refer when is_binary or is_bitstring in used outside of the function head",
+      status: :refer,
+      comments_include: [Constants.two_fer_use_function_level_guard()] do
+      [
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            is_binary(name)
+            "One for #{name}, one for me"
+          end
+        end,
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            if is_bitstring(name) do
+              "One for #{name}, one for me"
+            else
+              raise FunctionClauseError
+            end
+          end
+        end
+      ]
+    end
+  end
+
+  describe "using auxiliary functions" do
+    test_exercise_analysis "refer there are other functions than two_fer/1",
+      comments_include: [Constants.two_fer_use_of_aux_functions()],
+      status: :refer do
+      [
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            "One for #{name}, one for me"
+          end
+
+          defp foo() do
+          end
+        end,
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            "One for #{name}, one for me"
+          end
+
+          defp foo(), do: nil
+        end,
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            "One for #{name}, one for me"
+          end
+
+          defp foo(_a), do: nil
+        end,
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            "One for #{name}, one for me"
+          end
+
+          defp foo(_a, _b), do: nil
+        end,
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            "One for #{name}, one for me"
+          end
+
+          def foo(_a, _b), do: nil
+        end,
+        defmodule TwoFer do
+          def foo(_a, _b, _c, _d), do: nil
+
+          def two_fer(name \\ "you") do
+            "One for #{name}, one for me"
+          end
+        end,
+        defmodule TwoFer do
+          def foo(_a) do
+          end
+
+          def two_fer(name \\ "you") do
+            "One for #{name}, one for me"
+          end
+        end
+      ]
+    end
+  end
+
+  describe "string interpolation" do
+    test_exercise_analysis "doesn't allow string concatenation",
+      comments_include: [Constants.two_fer_use_string_interpolation()],
+      status: :disapprove do
+      defmodule TwoFer do
+        def two_fer(name \\ "you") when is_binary(name) do
+          "One for " <> name <> ", one for me"
+        end
+      end
+    end
+  end
+
+  #  describe "FunctionClauseError" do
+  #    test_exercise_analysis "doesn't allow raising FunctionClauseError explicitly",
+  #      comments_include: [Constants.solution_raise_fn_clause_error()],
+  #      status: :disapprove do
+  #      defmodule TwoFer do
+  #        def two_fer(name \\ "you") do
+  #          if is_bitstring(name) do
+  #            "One for #{name}, one for me"
+  #          else
+  #            raise FunctionClauseError
+  #          end
+  #        end
+  #      end
+  #    end
+  #  end
 end

--- a/test/elixir_analyzer/exercise_test/two_fer_test.exs
+++ b/test/elixir_analyzer/exercise_test/two_fer_test.exs
@@ -1,74 +1,52 @@
 defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
-  use ExUnit.Case
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.ExerciseTest.TwoFer
 
-  alias ElixirAnalyzer.ExerciseTest.TwoFer
-  alias ElixirAnalyzer.{Submission, Constants}
-
-  test_cases = [
-    %{
-      name: "missing moduledoc",
-      status: :approve,
-      comments: [Constants.solution_use_moduledoc()],
-      code:
-        quote do
-          defmodule TwoFer do
-            @spec two_fer(String.t()) :: String.t()
-            def two_fer(name \\ "you") when is_binary(name) do
-              "One for #{name}, one for me"
-            end
-          end
-        end
-    },
-    %{
-      name: "wrong spec",
-      status: :refer,
-      comments: [Constants.two_fer_wrong_specification()],
-      code: [
-        quote do
-          defmodule TwoFer do
-            @moduledoc """
-            Two-fer or 2-fer is short for two for one. One for you and one for me.
-            """
-            @spec two_fer(binary()) :: binary()
-            def two_fer(name \\ "you") when is_binary(name) do
-              "One for #{name}, one for me"
-            end
-          end
-        end,
-        quote do
-          defmodule TwoFer do
-            @moduledoc """
-            Two-fer or 2-fer is short for two for one. One for you and one for me.
-            """
-            @spec two_fer(bitstring()) :: bitstring()
-            def two_fer(name \\ "you") when is_binary(name) do
-              "One for #{name}, one for me"
-            end
-          end
-        end
-      ]
-    }
-  ]
-
-  Enum.map(test_cases, fn test_case ->
-    test_case.code
-    |> List.wrap()
-    |> Enum.with_index()
-    |> Enum.map(fn {code, index} ->
-      test "#{test_case.name} - code sample #{index + 1}" do
-        result = TwoFer.analyze(empty_submission(), unquote(Macro.to_string(code)))
-        assert result.status == unquote(test_case.status)
-        assert result.comments == unquote(test_case.comments)
+  test_exercise_analysis "perfect solution",
+    status: :approve,
+    comments: [] do
+    defmodule TwoFer do
+      @moduledoc """
+      Two-fer or 2-fer is short for two for one. One for you and one for me.
+      """
+      @spec two_fer(String.t()) :: String.t()
+      def two_fer(name \\ "you") when is_binary(name) do
+        "One for #{name}, one for me"
       end
-    end)
-  end)
+    end
+  end
 
-  defp empty_submission() do
-    %Submission{
-      code_file: "",
-      code_path: "",
-      path: "",
-      analysis_module: ""
-    }
+  test_exercise_analysis "missing moduledoc",
+    status: :approve,
+    comments: [Constants.solution_use_moduledoc()] do
+    defmodule TwoFer do
+      @spec two_fer(String.t()) :: String.t()
+      def two_fer(name \\ "you") when is_binary(name) do
+        "One for #{name}, one for me"
+      end
+    end
+  end
+
+  test_exercise_analysis "correct spec",
+    comments_exclude: [Constants.two_fer_wrong_specification()] do
+    defmodule TwoFer do
+      @spec two_fer(String.t()) :: String.t()
+      def two_fer(name)
+    end
+  end
+
+  test_exercise_analysis "wrong spec",
+    status: :refer,
+    comments_include: [Constants.two_fer_wrong_specification()] do
+    [
+      defmodule TwoFer do
+        @spec two_fer(binary()) :: binary()
+        def two_fer(name)
+      end,
+      defmodule TwoFer do
+        @spec two_fer(bitstring()) :: bitstring()
+        def two_fer(name)
+      end
+    ]
   end
 end

--- a/test/elixir_analyzer/exercise_test/two_fer_test.exs
+++ b/test/elixir_analyzer/exercise_test/two_fer_test.exs
@@ -113,15 +113,15 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
     end
   end
 
-  #  describe "function header" do
-  #    test_exercise_analysis "refer when using a function header",
-  #      status: :refer,
-  #      comments_include: [Constants.two_fer_use_of_function_header()] do
-  #      defmodule TwoFer do
-  #        def two_fer(name \\ "you") when is_binary(name)
-  #      end
-  #    end
-  #  end
+  describe "function header" do
+    test_exercise_analysis "refer when using a function header",
+      status: :refer,
+      comments_include: [Constants.two_fer_use_of_function_header()] do
+      defmodule TwoFer do
+        def two_fer(name \\ "you")
+      end
+    end
+  end
 
   describe "guards" do
     test_exercise_analysis "usage of is_binary or is_bitstring is required",

--- a/test/elixir_analyzer/exercise_test/two_fer_test.exs
+++ b/test/elixir_analyzer/exercise_test/two_fer_test.exs
@@ -1,0 +1,67 @@
+defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
+  use ExUnit.Case
+
+  alias ElixirAnalyzer.ExerciseTest.TwoFer
+  alias ElixirAnalyzer.{Submission, Constants}
+
+  test_cases = [
+    %{
+      name: "missing moduledoc",
+      status: :approve,
+      comments: [Constants.solution_use_moduledoc()],
+      code: ~S"""
+        defmodule TwoFer do
+          @spec two_fer(String.t()) :: String.t()
+          def two_fer(name \\ "you") when is_binary(name) do
+            "One for #{name}, one for me"
+          end
+        end
+      """
+    },
+    %{
+      name: "wrong spec",
+      status: :refer,
+      comments: [Constants.solution_use_moduledoc(), Constants.two_fer_wrong_specification()],
+      code: [
+        ~S"""
+          defmodule TwoFer do
+            @spec two_fer(binary()) :: binary()
+            def two_fer(name \\ "you") when is_binary(name) do
+              "One for #{name}, one for me"
+            end
+          end
+        """,
+        ~S"""
+          defmodule TwoFer do
+            @spec two_fer(bitstring()) :: bitstring()
+            def two_fer(name \\ "you") when is_binary(name) do
+              "One for #{name}, one for me"
+            end
+          end
+        """
+      ]
+    }
+  ]
+
+  Enum.map(test_cases, fn test_case ->
+    test_case.code
+    |> List.wrap()
+    |> Enum.with_index()
+    |> Enum.map(fn {code, index} ->
+      test "#{test_case.name} - code sample #{index + 1}" do
+        result = TwoFer.analyze(empty_submission(), unquote(code))
+        assert result.status == unquote(test_case.status)
+        assert result.comments == unquote(test_case.comments)
+      end
+    end)
+  end)
+
+  defp empty_submission() do
+    %Submission{
+      code_file: "",
+      code_path: "",
+      path: "",
+      analysis_module: ""
+    }
+  end
+end

--- a/test/elixir_analyzer/exercise_test/two_fer_test.exs
+++ b/test/elixir_analyzer/exercise_test/two_fer_test.exs
@@ -9,36 +9,43 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
       name: "missing moduledoc",
       status: :approve,
       comments: [Constants.solution_use_moduledoc()],
-      code: ~S"""
-        defmodule TwoFer do
-          @spec two_fer(String.t()) :: String.t()
-          def two_fer(name \\ "you") when is_binary(name) do
-            "One for #{name}, one for me"
+      code:
+        quote do
+          defmodule TwoFer do
+            @spec two_fer(String.t()) :: String.t()
+            def two_fer(name \\ "you") when is_binary(name) do
+              "One for #{name}, one for me"
+            end
           end
         end
-      """
     },
     %{
       name: "wrong spec",
       status: :refer,
-      comments: [Constants.solution_use_moduledoc(), Constants.two_fer_wrong_specification()],
+      comments: [Constants.two_fer_wrong_specification()],
       code: [
-        ~S"""
+        quote do
           defmodule TwoFer do
+            @moduledoc """
+            Two-fer or 2-fer is short for two for one. One for you and one for me.
+            """
             @spec two_fer(binary()) :: binary()
             def two_fer(name \\ "you") when is_binary(name) do
               "One for #{name}, one for me"
             end
           end
-        """,
-        ~S"""
+        end,
+        quote do
           defmodule TwoFer do
+            @moduledoc """
+            Two-fer or 2-fer is short for two for one. One for you and one for me.
+            """
             @spec two_fer(bitstring()) :: bitstring()
             def two_fer(name \\ "you") when is_binary(name) do
               "One for #{name}, one for me"
             end
           end
-        """
+        end
       ]
     }
   ]
@@ -49,7 +56,7 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
     |> Enum.with_index()
     |> Enum.map(fn {code, index} ->
       test "#{test_case.name} - code sample #{index + 1}" do
-        result = TwoFer.analyze(empty_submission(), unquote(code))
+        result = TwoFer.analyze(empty_submission(), unquote(Macro.to_string(code)))
         assert result.status == unquote(test_case.status)
         assert result.comments == unquote(test_case.comments)
       end

--- a/test/elixir_analyzer/exercise_test/two_fer_test.exs
+++ b/test/elixir_analyzer/exercise_test/two_fer_test.exs
@@ -158,6 +158,19 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
   end
 
   describe "using auxiliary functions" do
+    test_exercise_analysis "multiple implementations of two_fer/1 don't count as auxiliary functions",
+      comments_exclude: [Constants.two_fer_use_of_aux_functions()] do
+      defmodule TwoFer do
+        def two_fer("foo") do
+          "One for foo, one for me"
+        end
+
+        def two_fer(name) do
+          "One for #{name}, one for me"
+        end
+      end
+    end
+
     test_exercise_analysis "refer there are other functions than two_fer/1",
       comments_include: [Constants.two_fer_use_of_aux_functions()],
       status: :refer do
@@ -190,29 +203,29 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
           end
 
           defp foo(_a, _b), do: nil
-        end,
-        defmodule TwoFer do
-          def two_fer(name \\ "you") do
-            "One for #{name}, one for me"
-          end
-
-          def foo(_a, _b), do: nil
-        end,
-        defmodule TwoFer do
-          def foo(_a, _b, _c, _d), do: nil
-
-          def two_fer(name \\ "you") do
-            "One for #{name}, one for me"
-          end
-        end,
-        defmodule TwoFer do
-          def foo(_a) do
-          end
-
-          def two_fer(name \\ "you") do
-            "One for #{name}, one for me"
-          end
         end
+        #        defmodule TwoFer do
+        #          def two_fer(name \\ "you") do
+        #            "One for #{name}, one for me"
+        #          end
+        #
+        #          def foo(_a, _b), do: nil
+        #        end,
+        #        defmodule TwoFer do
+        #          def foo(_a, _b, _c, _d), do: nil
+        #
+        #          def two_fer(name \\ "you") do
+        #            "One for #{name}, one for me"
+        #          end
+        #        end,
+        #        defmodule TwoFer do
+        #          def foo(_a) do
+        #          end
+        #
+        #          def two_fer(name \\ "you") do
+        #            "One for #{name}, one for me"
+        #          end
+        #        end
       ]
     end
   end

--- a/test/elixir_analyzer/exercise_test/two_fer_test.exs
+++ b/test/elixir_analyzer/exercise_test/two_fer_test.exs
@@ -204,28 +204,6 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
 
           defp foo(_a, _b), do: nil
         end
-        #        defmodule TwoFer do
-        #          def two_fer(name \\ "you") do
-        #            "One for #{name}, one for me"
-        #          end
-        #
-        #          def foo(_a, _b), do: nil
-        #        end,
-        #        defmodule TwoFer do
-        #          def foo(_a, _b, _c, _d), do: nil
-        #
-        #          def two_fer(name \\ "you") do
-        #            "One for #{name}, one for me"
-        #          end
-        #        end,
-        #        defmodule TwoFer do
-        #          def foo(_a) do
-        #          end
-        #
-        #          def two_fer(name \\ "you") do
-        #            "One for #{name}, one for me"
-        #          end
-        #        end
       ]
     end
   end
@@ -242,18 +220,18 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
     end
   end
 
-    describe "FunctionClauseError" do
-      test_exercise_analysis "doesn't allow raising FunctionClauseError explicitly",
-        comments_include: [Constants.solution_raise_fn_clause_error()] do
-        defmodule TwoFer do
-          def two_fer(name \\ "you") do
-            if is_bitstring(name) do
-              "One for #{name}, one for me"
-            else
-              raise FunctionClauseError
-            end
+  describe "FunctionClauseError" do
+    test_exercise_analysis "doesn't allow raising FunctionClauseError explicitly",
+      comments_include: [Constants.solution_raise_fn_clause_error()] do
+      defmodule TwoFer do
+        def two_fer(name \\ "you") do
+          if is_bitstring(name) do
+            "One for #{name}, one for me"
+          else
+            raise FunctionClauseError
           end
         end
       end
     end
+  end
 end

--- a/test/elixir_analyzer/exercise_test/two_fer_test.exs
+++ b/test/elixir_analyzer/exercise_test/two_fer_test.exs
@@ -242,19 +242,18 @@ defmodule ElixirAnalyzer.ExerciseTest.TwoFerTest do
     end
   end
 
-  #  describe "FunctionClauseError" do
-  #    test_exercise_analysis "doesn't allow raising FunctionClauseError explicitly",
-  #      comments_include: [Constants.solution_raise_fn_clause_error()],
-  #      status: :disapprove do
-  #      defmodule TwoFer do
-  #        def two_fer(name \\ "you") do
-  #          if is_bitstring(name) do
-  #            "One for #{name}, one for me"
-  #          else
-  #            raise FunctionClauseError
-  #          end
-  #        end
-  #      end
-  #    end
-  #  end
+    describe "FunctionClauseError" do
+      test_exercise_analysis "doesn't allow raising FunctionClauseError explicitly",
+        comments_include: [Constants.solution_raise_fn_clause_error()] do
+        defmodule TwoFer do
+          def two_fer(name \\ "you") do
+            if is_bitstring(name) do
+              "One for #{name}, one for me"
+            else
+              raise FunctionClauseError
+            end
+          end
+        end
+      end
+    end
 end

--- a/test/support/exercise_test_case.ex
+++ b/test/support/exercise_test_case.ex
@@ -78,7 +78,9 @@ defmodule ElixirAnalyzer.ExerciseTestCase do
           _ -> name
         end
 
-      quote location: :keep do
+      {_, [line: line], _} = code
+
+      quote line: line do
         test "#{unquote(test_name)}" do
           empty_submission = %ElixirAnalyzer.Submission{
             code_file: "",

--- a/test/support/exercise_test_case.ex
+++ b/test/support/exercise_test_case.ex
@@ -1,0 +1,127 @@
+defmodule ElixirAnalyzer.ExerciseTestCase do
+  @moduledoc """
+    A test case for exercise test module tests.
+
+    ## Usage
+
+    ```
+    use ElixirAnalyzer.ExerciseTestCase, exercise_test_module: ElixirAnalyzer.ExerciseTest.ExerciseName
+    ```
+  """
+
+  use ExUnit.CaseTemplate
+
+  using opts do
+    quote do
+      @exercise_test_module unquote(opts)[:exercise_test_module]
+      require ElixirAnalyzer.ExerciseTestCase
+      import ElixirAnalyzer.ExerciseTestCase
+      alias ElixirAnalyzer.Constants
+    end
+  end
+
+  @doc ~S"""
+    Defines test cases for the exercise test module.
+
+    ## Usage
+
+    ```
+    test_exercise_analysis "missing moduledoc",
+      status: :approve,
+      comments: [Constants.solution_use_moduledoc()] do
+      defmodule TwoFer do
+        @spec two_fer(String.t()) :: String.t()
+        def two_fer(name \\ "you") when is_binary(name) do
+          "One for #{name}, one for me"
+        end
+      end
+    end
+    ```
+
+    ## Assertions
+
+    All assertions are optional, but at least one is required.
+
+    - `:status` - an atom, e.g. `:approve`, `:refer`, `:disapprove`.
+    - `:comments` - checks that the comments produced by the analysis and this list have the same elements, ignoring their order.
+    - `:comments_include` - checks that the comments produced by the analysis include all elements from this list.
+    - `:comments_exclude` - checks that the comments produced by the analysis include none of the elements from this list.
+
+    ## Code
+
+    The code of solutions to be analyzed should be passed in the `do` block directly, without quoting.
+    Passing a list of code blocks is also supported.
+  """
+  defmacro test_exercise_analysis(name, assertions, do: test_cases) do
+    supported_opt_keys = [:status, :comments, :comments_include, :comments_exclude]
+    opt_keys = Keyword.keys(assertions)
+    opt_key_diff = opt_keys -- supported_opt_keys
+
+    if opt_keys == [] do
+      raise "Expected to receive at least one of the supported options: #{
+              Enum.join(supported_opt_keys)
+            }"
+    end
+
+    if opt_key_diff != [] do
+      raise "Unsupported options received: #{Enum.join(opt_key_diff)}"
+    end
+
+    test_cases = List.wrap(test_cases)
+
+    test_cases
+    |> Enum.with_index()
+    |> Enum.map(fn {code, index} ->
+      test_name =
+        case test_cases do
+          [_, _ | _] -> "#{name} #{index + 1}"
+          _ -> name
+        end
+
+      quote location: :keep do
+        test "#{unquote(test_name)}" do
+          empty_submission = %ElixirAnalyzer.Submission{
+            code_file: "",
+            code_path: "",
+            path: "",
+            analysis_module: ""
+          }
+
+          result =
+            @exercise_test_module.analyze(
+              empty_submission,
+              unquote(Macro.to_string(code))
+            )
+
+          expected_status = unquote(assertions[:status])
+
+          if expected_status do
+            assert result.status == expected_status
+          end
+
+          expected_comments = unquote(assertions[:comments])
+
+          if expected_comments do
+            assert Enum.sort(result.comments) == Enum.sort(expected_comments)
+          end
+
+          comments_include = unquote(assertions[:comments_include])
+
+          if comments_include do
+            Enum.each(comments_include, fn comment ->
+              assert comment in result.comments
+            end)
+          end
+
+          comments_exclude = unquote(assertions[:comments_exclude])
+
+          if comments_exclude do
+            Enum.each(comments_exclude, fn comment ->
+              refute comment in result.comments
+            end)
+          end
+        end
+      end
+    end)
+  end
+end


### PR DESCRIPTION
This PR proves that it's possible to have unit tests for each exercise test module (e.g. `ElixirAnalyzer.ExerciseTest.TwoFer`) a predefined set of exercise submissions and expected analysis results.

Will it be enough for us to test the output of the whole analysis for an exercise, or would we want to find a solution that allows us to test single `feature`s?

If this is enough, then the next step would be to write some nice macros for generating those tests so that the current boilerplate in `ElixirAnalyzer.ExerciseTest.TwoFerTest` can be hidden away and doesn't need to be copied to each test file. Ideally it should also be possible to use `mix task` with the filepath and line number to only run one of the test cases.

One problem that I couldn't figure out is how to write a multiline string that contains another multiline string. I thought this would work:

```elixir
~S"""
  defmodule TwoFer do
    @doc \"\"\"
    Two-fer or 2-fer is short for two for one. One for you and one for me.
    \"\"\"
    @spec two_fer(binary()) :: binary()
    def two_fer(name \\ "you") when is_binary(name) do
      "One for #{name}, one for me"
    end
  end
"""
```

But that code causes `Code.string_to_quoted` to return
```
{:error, {2, "unexpected token: ", "\"\\\" (column 10, code point U+005C)"}}
```