### PR TITLE
fix AST pattern generation for some block expressions

### DIFF
--- a/lib/elixir_analyzer/exercise_test.ex
+++ b/lib/elixir_analyzer/exercise_test.ex
@@ -76,8 +76,17 @@ defmodule ElixirAnalyzer.ExerciseTest do
 
     {ast, block_params} =
       case ast do
-        {:__block__, _, params} -> {params, length(params)}
-        _ -> {ast, false}
+        {:__block__, _, params} ->
+          case length(params) do
+            1 ->
+              {hd(params), false}
+
+            len ->
+              {params, len}
+          end
+
+        _ ->
+          {ast, false}
       end
 
     find_ast_string =
@@ -208,8 +217,6 @@ defmodule ElixirAnalyzer.ExerciseTest do
             _ -> true
           end) and auto_approvable
 
-        # {approved, disapproved, referred} |> IO.inspect(label: "exercise status {approve, disapprove, referred}")
-
         case {approved, disapproved, referred} do
           {_, _, true} -> Submission.refer(s)
           {_, true, false} -> Submission.disapprove(s)
@@ -326,8 +333,6 @@ defmodule ElixirAnalyzer.ExerciseTest do
     quote do
       fn
         node, false, depth ->
-          # IO.inspect({node, depth, inspect(unquote(Macro.escape(find_ast))), unquote(find_at_depth)}, label: ">>>")
-
           finding_depth = unquote(find_at_depth) in [nil, depth]
 
           cond do

--- a/lib/elixir_analyzer/exercise_test.ex
+++ b/lib/elixir_analyzer/exercise_test.ex
@@ -76,14 +76,11 @@ defmodule ElixirAnalyzer.ExerciseTest do
 
     {ast, block_params} =
       case ast do
-        {:__block__, _, params} ->
-          case length(params) do
-            1 ->
-              {hd(params), false}
+        {:__block__, _, [param]} ->
+          {param, false}
 
-            len ->
-              {params, len}
-          end
+        {:__block__, _, [_ | _] = params}  ->
+          {params, length(params)}
 
         _ ->
           {ast, false}


### PR DESCRIPTION
when creating AST, elixir handles some expressions differently from others depending on what it determines the contend of a `do...end` block to contain.  For example:
```elixir
foo do
  !boolean
end
```
results in :
```elixir
{:foo, [],
 [
   [
     do: {:__block__, [],
      [{:!, [context: Elixir, import: Kernel], [{:boolean, [], Elixir}]}]}
   ]
 ]}
```
Whereas:
```elixir
foo do
  bar(boolean)
end
```
Results in:
```elixir
{:foo, [], [[do: {:bar, [], [{:boolean, [], Elixir}]}]]}
```

This caused a pattern match problem when applied to the `form` block used by the analyzer.  Some unary functions (like `!`) wer not being unwrapped from the block causing them never to match. This patch fixes by unwrapping `form` blocks with only 1 expression even if it was determined by Elixir to wrap it in a block.

---

@angelikatyborska I did add in your pacman test to this locally and it did seem to pass all of the tests that you had fail, but if you test this patch it may be worthwhile to temporarily add in your analyzer module / test file to just make sure. I haven't missed something else.