### PR TITLE
New location of analyzer comments

### DIFF
--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -18,4 +18,4 @@ jobs:
         mix local.hex --force
         mix deps.get
     - name: Run Tests
-      run: mix test
+      run: mix test --include external

--- a/.github/workflows/elixir_test_external.yml
+++ b/.github/workflows/elixir_test_external.yml
@@ -1,4 +1,4 @@
-name: Elixir Test
+name: Elixir External Text
 
 on: [push, pull_request]
 
@@ -18,4 +18,4 @@ jobs:
         mix local.hex --force
         mix deps.get
     - name: Run Tests
-      run: mix test --exclude external
+      run: mix test --only external

--- a/.github/workflows/elixir_test_external.yml
+++ b/.github/workflows/elixir_test_external.yml
@@ -1,4 +1,4 @@
-name: Elixir External Text
+name: Elixir External Test
 
 on: [push, pull_request]
 

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -19,16 +19,16 @@ defmodule ElixirAnalyzer.Constants do
     two_fer_use_guards: "elixir.two-fer.use_guards",
     two_fer_use_string_interpolation: "elixir.two-fer.use_string_interpolation",
     two_fer_wrong_specification: "elixir.two-fer.wrong_specification",
-    two_fer_use_function_level_guard: "elixir.two_fer.use_function_level_guard",
-    two_fer_use_of_aux_functions: "elixir.two_fer.use_of_aux_functions",
-    two_fer_use_of_function_header: "elixir.two_fer.use_of_function_header",
+    two_fer_use_function_level_guard: "elixir.two-fer.use_function_level_guard",
+    two_fer_use_of_aux_functions: "elixir.two-fer.use_of_aux_functions",
+    two_fer_use_of_function_header: "elixir.two-fer.use_of_function_header",
 
     # Pacman Rules Comments
     pacman_rules_use_strictly_boolean_operators:
-      "elixir.pacman_rules.use_strictly_boolean_operators",
+      "elixir.pacman-rules.use_strictly_boolean_operators",
 
     # Take A Number Comments
-    take_a_number_do_not_use_abstractions: "elixir.take_a_number.do_not_use_abstractions"
+    take_a_number_do_not_use_abstractions: "elixir.take-a-number.do_not_use_abstractions"
   ]
 
   for {constant, markdown} <- @constants do

--- a/lib/elixir_analyzer/exercise_test.ex
+++ b/lib/elixir_analyzer/exercise_test.ex
@@ -122,7 +122,13 @@ defmodule ElixirAnalyzer.ExerciseTest do
         end
       end
 
-      defp append_analysis_failure(s = %Submission{}, {line, error, token}) do
+      defp append_analysis_failure(s = %Submission{}, {location, error, token}) do
+        line =
+          case location do
+            l when is_integer(l) -> l
+            l when is_list(l) -> Keyword.get(location, :line)
+          end
+
         comment_params = %{line: line, error: "#{error}#{token}"}
 
         Submission.append_comment(s, {Constants.general_parsing_error(), comment_params})

--- a/test/elixir_analyzer/constants_test.exs
+++ b/test/elixir_analyzer/constants_test.exs
@@ -13,7 +13,7 @@ defmodule ElixirAnalyzer.ConstantsTest do
 
   describe "if comment exists at exercism/website-copy" do
     @comments Constants.list_of_all_comments()
-    @website_copy_url "https://github.com/exercism/website-copy/blob/master/automated-comments/"
+    @website_copy_url "https://github.com/exercism/website-copy/blob/master/analyzer-comments/"
     @file_ext ".md"
 
     for comment <- @comments do

--- a/test/elixir_analyzer_test.exs
+++ b/test/elixir_analyzer_test.exs
@@ -27,7 +27,7 @@ defmodule ElixirAnalyzerTest do
       analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, path, @options)
 
       expected_output = """
-      {\"comments\":[\"elixir.solution.use_module_doc\",\"elixir.solution.raise_fn_clause_error\",\"elixir.two_fer.use_of_function_header\",\"elixir.solution.use_specification\"],\"status\":\"refer_to_mentor\"}
+      {\"comments\":[\"elixir.solution.use_module_doc\",\"elixir.solution.raise_fn_clause_error\",\"elixir.two-fer.use_of_function_header\",\"elixir.solution.use_specification\"],\"status\":\"refer_to_mentor\"}
       """
 
       assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)


### PR DESCRIPTION
Analyzer comments were moved in that PR: https://github.com/exercism/website-copy/pull/1898

On top of fixing that location, this PR:
- makes the external (analyzer comments) test run on CI so we don't forget that some comments are missing
- fixes the paths of some existing comments (exercise names use dashes instead of underscores)
- fixes an unrelated unit test failure about extracting the line number