### PR TITLE
add wildcard function matcher

### DIFF
--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -130,6 +130,13 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
   def matching_function_call?(_node, nil), do: false
 
   def matching_function_call?(
+        {{:., _, [{:__aliases__, _, module_path}, _name]}, _, _args},
+        {module_path, :*}
+      ) do
+    true
+  end
+
+  def matching_function_call?(
         {{:., _, [{:__aliases__, _, module_path}, name]}, _, _args},
         {module_path, name}
       ) do

--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -131,7 +131,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
 
   def matching_function_call?(
         {{:., _, [{:__aliases__, _, module_path}, _name]}, _, _args},
-        {module_path, :*}
+        {module_path, :_}
       ) do
     true
   end

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -6,6 +6,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
     comments: [] do
     defmodule AssertCallVerification do
       def function() do
+        List.first([1, 2, 3])
         result = helper()
         IO.puts(result)
 
@@ -29,6 +30,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
     ] do
     defmodule AssertCallVerification do
       def function() do
+        List.last([1, 2, 3])
         private_helper() |> IO.puts()
       end
 
@@ -49,6 +51,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
     ] do
     defmodule AssertCallVerification do
       def function() do
+        List.first([1, 2, 3])
         other()
         IO.puts("1")
       end
@@ -75,6 +78,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
     ] do
     defmodule AssertCallVerification do
       def function() do
+        List.flatten([1, 2, 3])
         result = helper()
         private_helper()
       end
@@ -95,12 +99,59 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
     ] do
     defmodule AssertCallVerification do
       def function() do
+        List.first([1, 2, 3])
         result = helper()
         private_helper() |> other()
       end
 
       def other(x) do
         IO.puts(x)
+      end
+
+      def helper do
+        :helped
+      end
+
+      defp private_helper do
+        :privately_helped
+      end
+    end
+  end
+
+  test_exercise_analysis "missing call to a List function in function/0 solution",
+    comments: [
+      "didn't find a call to a List function in function/0"
+    ] do
+    defmodule AssertCallVerification do
+      def function() do
+        result = helper()
+        IO.puts(result)
+
+        private_helper() |> IO.puts()
+      end
+
+      def helper do
+        List.first([1, 2, 3])
+        :helped
+      end
+
+      defp private_helper do
+        :privately_helped
+      end
+    end
+  end
+
+  test_exercise_analysis "missing call to a List function in solution",
+    comments: [
+      "didn't find a call to a List function",
+      "didn't find a call to a List function in function/0"
+    ] do
+    defmodule AssertCallVerification do
+      def function() do
+        result = helper()
+        IO.puts(result)
+
+        private_helper() |> IO.puts()
       end
 
       def helper do

--- a/test/elixir_analyzer/exercise_test/assert_no_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_no_call_test.exs
@@ -96,4 +96,24 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertNoCallTest do
       end
     end
   end
+
+  test_exercise_analysis "test wildcard",
+    comments: [
+      "don't call List module functions"
+    ] do
+    defmodule AssertNoCallVerification do
+      def function() do
+        "something"
+        List.last([])
+      end
+
+      def helper do
+        :helped
+      end
+
+      defp private_helper do
+        :privately_helped
+      end
+    end
+  end
 end

--- a/test/support/analyzer_verification/assert_call.ex
+++ b/test/support/analyzer_verification/assert_call.ex
@@ -47,13 +47,13 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.AssertCall do
 
   assert_call "finds call to any List function anywhere" do
     type :informational
-    called_fn module: List, name: :*
+    called_fn module: List, name: :_
     comment "didn't find a call to a List function"
   end
 
   assert_call "finds call to any List function anywhere" do
     type :informational
-    called_fn module: List, name: :*
+    called_fn module: List, name: :_
     calling_fn module: AssertCallVerification, name: :function
     comment "didn't find a call to a List function in function/0"
   end

--- a/test/support/analyzer_verification/assert_call.ex
+++ b/test/support/analyzer_verification/assert_call.ex
@@ -44,4 +44,17 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.AssertCall do
     calling_fn module: AssertCallVerification, name: :function
     comment "didn't find a call to IO.puts/1 in function/0"
   end
+
+  assert_call "finds call to any List function anywhere" do
+    type :informational
+    called_fn module: List, name: :*
+    comment "didn't find a call to a List function"
+  end
+
+  assert_call "finds call to any List function anywhere" do
+    type :informational
+    called_fn module: List, name: :*
+    calling_fn module: AssertCallVerification, name: :function
+    comment "didn't find a call to a List function in function/0"
+  end
 end

--- a/test/support/analyzer_verification/assert_no_call.ex
+++ b/test/support/analyzer_verification/assert_no_call.ex
@@ -34,7 +34,7 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.AssertNoCall do
 
   assert_no_call "does not call any function from List module" do
     type :informational
-    called_fn module: List, name: :*
+    called_fn module: List, name: :_
     comment "don't call List module functions"
   end
 end

--- a/test/support/analyzer_verification/assert_no_call.ex
+++ b/test/support/analyzer_verification/assert_no_call.ex
@@ -31,4 +31,10 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.AssertNoCall do
     called_fn module: Atom, name: :to_string
     comment "found a call to Atom.to_string/1 in helper/0 function in solution"
   end
+
+  assert_no_call "does not call any function from List module" do
+    type :informational
+    called_fn module: List, name: :*
+    comment "don't call List module functions"
+  end
 end


### PR DESCRIPTION
When specifying a function to be called or not called you can now use `:*` to specify a wilcard function name.  This will then match any function from a specified module;

```elixir
  assert_no_call "does not call any function from List module" do
    type :informational
    called_fn module: List, name: :*
    comment "don't call List module functions"
  end
```
  