### PR TITLE
Should support functions in assert_call test cases now

### DIFF
--- a/lib/elixir_analyzer/exercise_test/assert_call.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call.ex
@@ -68,8 +68,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall do
     {node, Map.put(test_data, :called_fn, formatted_signature)}
   end
 
-  defp do_walk_assert_call_block({:comment, _, [comment]} = node, test_data)
-       when is_binary(comment) do
+  defp do_walk_assert_call_block({:comment, _, [comment]} = node, test_data) do
     {node, Map.put(test_data, :comment, comment)}
   end
 

--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -12,7 +12,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
     name = assert_call_data.description
     called_fn = Macro.escape(assert_call_data.called_fn)
     calling_fn = Macro.escape(assert_call_data.calling_fn)
-    comment = assert_call_data.comment
+    {comment, _} = Code.eval_quoted(assert_call_data.comment)
     should_call = assert_call_data.should_call
     type = assert_call_data.type
 

--- a/lib/test_suite/bird_count.ex
+++ b/lib/test_suite/bird_count.ex
@@ -5,24 +5,23 @@ defmodule ElixirAnalyzer.TestSuite.BirdCount do
   """
 
   use ElixirAnalyzer.ExerciseTest
-  alias ElixirAnalyzer.Constants
 
   assert_no_call "does not call any Enum functions" do
     type :essential
     called_fn module: Enum, name: :_
-    comment Constants.bird_count_use_recursion()
+    comment ElixirAnalyzer.Constants.bird_count_use_recursion()
   end
 
   assert_no_call "does not call any Stream functions" do
     type :essential
     called_fn module: Stream, name: :_
-    comment Constants.bird_count_use_recursion()
+    comment ElixirAnalyzer.Constants.bird_count_use_recursion()
   end
 
   assert_no_call "does not call any List functions" do
     type :essential
     called_fn module: List, name: :_
-    comment Constants.bird_count_use_recursion()
+    comment ElixirAnalyzer.Constants.bird_count_use_recursion()
   end
 
   # TODO: also detect aliasing and importing those modules
@@ -30,7 +29,7 @@ defmodule ElixirAnalyzer.TestSuite.BirdCount do
   feature "doesn't use list comprehensions" do
     find :none
     type :essential
-    comment Constants.bird_count_use_recursion()
+    comment ElixirAnalyzer.Constants.bird_count_use_recursion()
 
     form do
       for _ignore <- _ignore do

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -120,7 +120,8 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
 
   test_exercise_analysis "missing call to a List function in function/0 solution",
     comments: [
-      "didn't find a call to a List function in function/0"
+      "didn't find a call to a List function in function/0",
+      "mock.constant"
     ] do
     defmodule AssertCallVerification do
       def function() do
@@ -144,7 +145,8 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
   test_exercise_analysis "missing call to a List function in solution",
     comments: [
       "didn't find a call to a List function",
-      "didn't find a call to a List function in function/0"
+      "didn't find a call to a List function in function/0",
+      "mock.constant"
     ] do
     defmodule AssertCallVerification do
       def function() do

--- a/test/support/analyzer_verification/assert_call.ex
+++ b/test/support/analyzer_verification/assert_call.ex
@@ -57,4 +57,11 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.AssertCall do
     calling_fn module: AssertCallVerification, name: :function
     comment "didn't find a call to a List function in function/0"
   end
+
+  assert_call "allows use of constants function" do
+    type :informational
+    called_fn module: List, name: :_
+    calling_fn module: AssertCallVerification, name: :function
+    comment ElixirAnalyzer.Support.Constants.mock_constant()
+  end
 end

--- a/test/support/contants.ex
+++ b/test/support/contants.ex
@@ -1,0 +1,3 @@
+defmodule ElixirAnalyzer.Support.Constants do
+  def mock_constant(), do: "mock.constant"
+end


### PR DESCRIPTION
After merging the `patch` branch and applying a quick fix for the lack-of-alias problem, another problem appears. The test for a perfect solution returns comments, three times the same comment. I think the reason is that this definition:
https://github.com/exercism/elixir-analyzer/blob/7b26a9bda8bcf8c6a4e2f489458648e5b38ee561/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex#L146-L151

Matches the usage of `_`, e.g. in `[h | _] = list` as a usage of a function named `:_`, which is the symbol we chose to mean "any function".