### PR TITLE
Add analysis for `freelancer-rates`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,8 +23,12 @@ use Mix.Config
 
 config :elixir_analyzer,
   exercise_config: %{
-    "two-fer" => %{
-      analyzer_module: ElixirAnalyzer.TestSuite.TwoFer
+    # concept exercises
+    "bird-count" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.BirdCount
+    },
+    "freelancer-rates" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.FreelancerRates
     },
     "pacman-rules" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.PacmanRules
@@ -32,8 +36,10 @@ config :elixir_analyzer,
     "take-a-number" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.TakeANumber
     },
-    "bird-count" => %{
-      analyzer_module: ElixirAnalyzer.TestSuite.BirdCount
+
+    # practice exercises
+    "two-fer" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.TwoFer
     }
   }
 

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -24,7 +24,6 @@ defmodule ElixirAnalyzer.Constants do
     solution_use_specification: "elixir.solution.use_specification",
     solution_raise_fn_clause_error: "elixir.solution.raise_fn_clause_error",
 
-
     # Concept exercises
 
     # Bird Count Comments
@@ -40,7 +39,6 @@ defmodule ElixirAnalyzer.Constants do
 
     # Take A Number Comments
     take_a_number_do_not_use_abstractions: "elixir.take-a-number.do_not_use_abstractions",
-
 
     # Practice exercises
 

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -24,14 +24,15 @@ defmodule ElixirAnalyzer.Constants do
     solution_use_specification: "elixir.solution.use_specification",
     solution_raise_fn_clause_error: "elixir.solution.raise_fn_clause_error",
 
-    # Two-fer Error Comments
-    two_fer_use_default_parameter: "elixir.two-fer.use_default_param",
-    two_fer_use_guards: "elixir.two-fer.use_guards",
-    two_fer_use_string_interpolation: "elixir.two-fer.use_string_interpolation",
-    two_fer_wrong_specification: "elixir.two-fer.wrong_specification",
-    two_fer_use_function_level_guard: "elixir.two-fer.use_function_level_guard",
-    two_fer_use_of_aux_functions: "elixir.two-fer.use_of_aux_functions",
-    two_fer_use_of_function_header: "elixir.two-fer.use_of_function_header",
+
+    # Concept exercises
+
+    # Bird Count Comments
+    bird_count_use_recursion: "elixir.bird-count.use_recursion",
+
+    # Freelancer Rates Comments
+    freelancer_rates_apply_discount_function_reuse:
+      "elixir.freelancer-rates.apply_discount_function_reuse",
 
     # Pacman Rules Comments
     pacman_rules_use_strictly_boolean_operators:
@@ -40,8 +41,17 @@ defmodule ElixirAnalyzer.Constants do
     # Take A Number Comments
     take_a_number_do_not_use_abstractions: "elixir.take-a-number.do_not_use_abstractions",
 
-    # Bird Count Comments
-    bird_count_use_recursion: "elixir.bird-count.use_recursion"
+
+    # Practice exercises
+
+    # Two-fer Error Comments
+    two_fer_use_default_parameter: "elixir.two-fer.use_default_param",
+    two_fer_use_guards: "elixir.two-fer.use_guards",
+    two_fer_use_string_interpolation: "elixir.two-fer.use_string_interpolation",
+    two_fer_wrong_specification: "elixir.two-fer.wrong_specification",
+    two_fer_use_function_level_guard: "elixir.two-fer.use_function_level_guard",
+    two_fer_use_of_aux_functions: "elixir.two-fer.use_of_aux_functions",
+    two_fer_use_of_function_header: "elixir.two-fer.use_of_function_header"
   ]
 
   for {constant, markdown} <- @constants do

--- a/lib/elixir_analyzer/test_suite/freelancer_rates.ex
+++ b/lib/elixir_analyzer/test_suite/freelancer_rates.ex
@@ -1,0 +1,21 @@
+defmodule ElixirAnalyzer.TestSuite.FreelancerRates do
+  @moduledoc """
+  This is an exercise analyzer extension module for the concept exercise Freelancer Rates
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+
+  assert_call "monthly_rate/2 reuses apply_discount/2" do
+    type :actionable
+    calling_function(module: FreelancerRates, name: :monthly_rate)
+    called_fn name: :apply_discount
+    comment ElixirAnalyzer.Constants.freelancer_rates_apply_discount_function_reuse()
+  end
+
+  assert_call "days_in_budget/2 reuses apply_discount/2" do
+    type :actionable
+    calling_function(module: FreelancerRates, name: :days_in_budget)
+    called_fn name: :apply_discount
+    comment ElixirAnalyzer.Constants.freelancer_rates_apply_discount_function_reuse()
+  end
+end

--- a/lib/elixir_analyzer/test_suite/freelancer_rates.ex
+++ b/lib/elixir_analyzer/test_suite/freelancer_rates.ex
@@ -7,14 +7,14 @@ defmodule ElixirAnalyzer.TestSuite.FreelancerRates do
 
   assert_call "monthly_rate/2 reuses apply_discount/2" do
     type :actionable
-    calling_function(module: FreelancerRates, name: :monthly_rate)
+    calling_fn module: FreelancerRates, name: :monthly_rate
     called_fn name: :apply_discount
     comment ElixirAnalyzer.Constants.freelancer_rates_apply_discount_function_reuse()
   end
 
   assert_call "days_in_budget/2 reuses apply_discount/2" do
     type :actionable
-    calling_function(module: FreelancerRates, name: :days_in_budget)
+    calling_fn module: FreelancerRates, name: :days_in_budget
     called_fn name: :apply_discount
     comment ElixirAnalyzer.Constants.freelancer_rates_apply_discount_function_reuse()
   end

--- a/test/elixir_analyzer/test_suite/freelancer_rates_test.exs
+++ b/test/elixir_analyzer/test_suite/freelancer_rates_test.exs
@@ -57,5 +57,29 @@ defmodule ElixirAnalyzer.ExerciseTest.FreelancerRatesTest do
         end
       end
     end
+
+    test_exercise_analysis "comment appears only once if both functions don't use apply_discount/2",
+      comments: [Constants.freelancer_rates_apply_discount_function_reuse()] do
+      defmodule FreelancerRates do
+        def monthly_rate(hourly_rate, discount) do
+          monthly_rate_before_discount = daily_rate(hourly_rate) * 22.0
+
+          monthly_rate_after_discount =
+            monthly_rate_before_discount - monthly_rate_before_discount * (discount / 100.0)
+
+          trunc(Float.ceil(monthly_rate_after_discount))
+        end
+
+        def days_in_budget(budget, hourly_rate, discount) do
+          daily_rate_before_discount = daily_rate(hourly_rate)
+
+          daily_rate_after_discount =
+            daily_rate_before_discount - daily_rate_before_discount * (discount / 100.0)
+
+          days_in_budget = budget / daily_rate_after_discount
+          Float.floor(days_in_budget, 1)
+        end
+      end
+    end
   end
 end

--- a/test/elixir_analyzer/test_suite/freelancer_rates_test.exs
+++ b/test/elixir_analyzer/test_suite/freelancer_rates_test.exs
@@ -43,7 +43,7 @@ defmodule ElixirAnalyzer.ExerciseTest.FreelancerRatesTest do
       end
     end
 
-    test_exercise_analysis "requires days_in_budget/2 to call apply_discount/2",
+    test_exercise_analysis "requires days_in_budget/3 to call apply_discount/2",
       comments: [Constants.freelancer_rates_apply_discount_function_reuse()] do
       defmodule FreelancerRates do
         def days_in_budget(budget, hourly_rate, discount) do

--- a/test/elixir_analyzer/test_suite/freelancer_rates_test.exs
+++ b/test/elixir_analyzer/test_suite/freelancer_rates_test.exs
@@ -81,5 +81,22 @@ defmodule ElixirAnalyzer.ExerciseTest.FreelancerRatesTest do
         end
       end
     end
+
+    test_exercise_analysis "calling function should match",
+      comments: [Constants.freelancer_rates_apply_discount_function_reuse()] do
+      defmodule FreelancerRates do
+        def daily_rate(hourly_rate) do
+          hourly_rate * 8.0
+        end
+
+        def apply_discount(before_discount, discount) do
+          before_discount - before_discount * (discount / 100.0)
+        end
+
+        def some_other_function() do
+          apply_discount(100, 3)
+        end
+      end
+    end
   end
 end

--- a/test/elixir_analyzer/test_suite/freelancer_rates_test.exs
+++ b/test/elixir_analyzer/test_suite/freelancer_rates_test.exs
@@ -1,0 +1,61 @@
+defmodule ElixirAnalyzer.ExerciseTest.FreelancerRatesTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.TestSuite.FreelancerRates
+
+  test_exercise_analysis "example solution",
+    comments: [] do
+    defmodule FreelancerRates do
+      def daily_rate(hourly_rate) do
+        hourly_rate * 8.0
+      end
+
+      def apply_discount(before_discount, discount) do
+        before_discount - before_discount * (discount / 100.0)
+      end
+
+      def monthly_rate(hourly_rate, discount) do
+        monthly_rate_before_discount = daily_rate(hourly_rate) * 22.0
+        monthly_rate_after_discount = apply_discount(monthly_rate_before_discount, discount)
+        trunc(Float.ceil(monthly_rate_after_discount))
+      end
+
+      def days_in_budget(budget, hourly_rate, discount) do
+        daily_rate_before_discount = daily_rate(hourly_rate)
+        daily_rate_after_discount = apply_discount(daily_rate_before_discount, discount)
+        days_in_budget = budget / daily_rate_after_discount
+        Float.floor(days_in_budget, 1)
+      end
+    end
+  end
+
+  describe "apply_discount/2 function reuse" do
+    test_exercise_analysis "requires monthly_rate/2 to call apply_discount/2",
+      comments: [Constants.freelancer_rates_apply_discount_function_reuse()] do
+      defmodule FreelancerRates do
+        def monthly_rate(hourly_rate, discount) do
+          monthly_rate_before_discount = daily_rate(hourly_rate) * 22.0
+
+          monthly_rate_after_discount =
+            monthly_rate_before_discount - monthly_rate_before_discount * (discount / 100.0)
+
+          trunc(Float.ceil(monthly_rate_after_discount))
+        end
+      end
+    end
+
+    test_exercise_analysis "requires days_in_budget/2 to call apply_discount/2",
+      comments: [Constants.freelancer_rates_apply_discount_function_reuse()] do
+      defmodule FreelancerRates do
+        def days_in_budget(budget, hourly_rate, discount) do
+          daily_rate_before_discount = daily_rate(hourly_rate)
+
+          daily_rate_after_discount =
+            daily_rate_before_discount - daily_rate_before_discount * (discount / 100.0)
+
+          days_in_budget = budget / daily_rate_after_discount
+          Float.floor(days_in_budget, 1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Per https://github.com/exercism/elixir/blob/main/exercises/concept/freelancer-rates/.meta/design.md#analyzer

I reordered the constants and config in this order: first concept exercises alphabetically, then practice exercises alphabetically. As we add more exercises, this should make it easier to find them on those two lists.

Corresponding website-copy PR: https://github.com/exercism/website-copy/pull/1990