### PR TITLE
Add analyzer for german-sysadmin

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,6 +33,9 @@ config :elixir_analyzer,
     "freelancer-rates" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.FreelancerRates
     },
+    "german-sysadmin" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.GermanSysadmin
+    },
     "pacman-rules" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.PacmanRules
     },

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -38,7 +38,7 @@ defmodule ElixirAnalyzer.Constants do
       "elixir.freelancer-rates.apply_discount_function_reuse",
 
     # German Sysadmin Comments
-    german_sysadmin_no_strings: "elixir.german-sysadmin.no_strings",
+    german_sysadmin_no_string: "elixir.german-sysadmin.no_string",
     german_sysadmin_use_case: "elixir.german-sysadmin.use_case",
 
     # Pacman Rules Comments

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -37,6 +37,10 @@ defmodule ElixirAnalyzer.Constants do
     freelancer_rates_apply_discount_function_reuse:
       "elixir.freelancer-rates.apply_discount_function_reuse",
 
+    # German Sysadmin Comments
+    german_sysadmin_no_strings: "elixir.german-sysadmin.no_strings",
+    german_sysadmin_use_case: "elixir.german-sysadmin.use_case",
+
     # Pacman Rules Comments
     pacman_rules_use_strictly_boolean_operators:
       "elixir.pacman-rules.use_strictly_boolean_operators",

--- a/lib/elixir_analyzer/test_suite/german_sysadmin.ex
+++ b/lib/elixir_analyzer/test_suite/german_sysadmin.ex
@@ -8,25 +8,25 @@ defmodule ElixirAnalyzer.TestSuite.GermanSysadmin do
   assert_no_call "doesn't convert anything to a string" do
     type :essential
     called_fn name: :to_string
-    comment ElixirAnalyzer.Constants.german_sysadmin_no_strings()
+    comment ElixirAnalyzer.Constants.german_sysadmin_no_string()
   end
 
   assert_no_call "doesn't convert anything to a charlist" do
     type :essential
     called_fn name: :to_charlist
-    comment ElixirAnalyzer.Constants.german_sysadmin_no_strings()
+    comment ElixirAnalyzer.Constants.german_sysadmin_no_string()
   end
 
   assert_no_call "doesn't use any string functions" do
     type :essential
     called_fn module: String, name: :_
-    comment ElixirAnalyzer.Constants.german_sysadmin_no_strings()
+    comment ElixirAnalyzer.Constants.german_sysadmin_no_string()
   end
 
   assert_no_call "doesn't create binaries from character codes" do
     type :essential
     called_fn name: :<<>>
-    comment ElixirAnalyzer.Constants.german_sysadmin_no_strings()
+    comment ElixirAnalyzer.Constants.german_sysadmin_no_string()
   end
 
   assert_call "using case is required" do

--- a/lib/elixir_analyzer/test_suite/german_sysadmin.ex
+++ b/lib/elixir_analyzer/test_suite/german_sysadmin.ex
@@ -1,0 +1,37 @@
+defmodule ElixirAnalyzer.TestSuite.GermanSysadmin do
+  @moduledoc """
+  This is an exercise analyzer extension module for the concept exercise German Sysadmin
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+
+  assert_no_call "doesn't convert anything to a string" do
+    type :essential
+    called_fn name: :to_string
+    comment ElixirAnalyzer.Constants.german_sysadmin_no_strings()
+  end
+
+  assert_no_call "doesn't convert anything to a charlist" do
+    type :essential
+    called_fn name: :to_charlist
+    comment ElixirAnalyzer.Constants.german_sysadmin_no_strings()
+  end
+
+  assert_no_call "doesn't use any string functions" do
+    type :essential
+    called_fn module: String, name: :_
+    comment ElixirAnalyzer.Constants.german_sysadmin_no_strings()
+  end
+
+  assert_no_call "doesn't create binaries from character codes" do
+    type :essential
+    called_fn name: :<<>>
+    comment ElixirAnalyzer.Constants.german_sysadmin_no_strings()
+  end
+
+  assert_call "using case is required" do
+    type :essential
+    called_fn name: :case
+    comment ElixirAnalyzer.Constants.german_sysadmin_use_case()
+  end
+end

--- a/test/elixir_analyzer/test_suite/german_sysadmin_test.exs
+++ b/test/elixir_analyzer/test_suite/german_sysadmin_test.exs
@@ -49,7 +49,7 @@ defmodule ElixirAnalyzer.ExerciseTest.GermanSysadminTest do
   end
 
   test_exercise_analysis "detects cheating with strings",
-    comments: [Constants.german_sysadmin_no_strings()] do
+    comments: [Constants.german_sysadmin_no_string()] do
     [
       defmodule Username do
         def sanitize(charlist) do

--- a/test/elixir_analyzer/test_suite/german_sysadmin_test.exs
+++ b/test/elixir_analyzer/test_suite/german_sysadmin_test.exs
@@ -1,0 +1,152 @@
+defmodule ElixirAnalyzer.ExerciseTest.GermanSysadminTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.TestSuite.GermanSysadmin
+
+  test_exercise_analysis "example solution",
+    comments: [] do
+    defmodule Username do
+      def sanitize('') do
+        ''
+      end
+
+      def sanitize([head | tail]) do
+        sanitized =
+          case head do
+            ?ß -> 'ss'
+            ?ä -> 'ae'
+            ?ö -> 'oe'
+            ?ü -> 'ue'
+            x when x >= ?a and x <= ?z -> [x]
+            ?_ -> '_'
+            _ -> ''
+          end
+
+        sanitized ++ sanitize(tail)
+      end
+    end
+  end
+
+  test_exercise_analysis "other valid solutions",
+    comments: [] do
+    defmodule Username do
+      def sanitize(list) do
+        List.foldr(list, [], fn code, acc ->
+          sanitized =
+            case code do
+              ?ß -> 'ss'
+              ?ä -> 'ae'
+              ?ö -> 'oe'
+              ?ü -> 'ue'
+              x when x >= ?a and x <= ?z -> [x]
+              ?_ -> '_'
+              _ -> ''
+            end
+
+          sanitized ++ acc
+        end)
+      end
+    end
+  end
+
+  test_exercise_analysis "detects cheating with strings",
+    comments: [Constants.german_sysadmin_no_strings()] do
+    [
+      defmodule Username do
+        def sanitize(charlist) do
+          charlist
+          |> Enum.filter(&(&1 < 0xD800))
+          |> to_string()
+          |> String.split("", trim: true)
+          |> Enum.map(fn letter ->
+            case letter do
+              "ß" ->
+                "ss"
+
+              "ä" ->
+                "ae"
+
+              "ö" ->
+                "oe"
+
+              "ü" ->
+                "ue"
+
+              letter when letter in ~w(a b c d e f g h i j k l m n o p q r s t u v w x y z) ->
+                letter
+
+              "_" ->
+                "_"
+
+              _ ->
+                ""
+            end
+          end)
+          |> Enum.join("")
+          |> to_charlist()
+        end
+      end,
+      defmodule Username do
+        def sanitize(list) do
+          List.foldr(list, "", fn code, acc ->
+            sanitized =
+              case code do
+                ?ß -> "ss"
+                ?ä -> "ae"
+                ?ö -> "oe"
+                ?ü -> "ue"
+                x when x >= ?a and x <= ?z -> <<x>>
+                ?_ -> "_"
+                _ -> ""
+              end
+
+            sanitized <> acc
+          end)
+          |> to_charlist()
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "using case is required",
+    comments: [Constants.german_sysadmin_use_case()] do
+    [
+      defmodule Username do
+        def sanitize('') do
+          ''
+        end
+
+        def sanitize([head | tail]) do
+          sanitized =
+            cond do
+              head == ?ß -> 'ss'
+              head == ?ä -> 'ae'
+              head == ?ö -> 'oe'
+              head == ?ü -> 'ue'
+              head >= ?a and head <= ?z -> [head]
+              head == ?_ -> '_'
+              true -> ''
+            end
+
+          sanitized ++ sanitize(tail)
+        end
+      end,
+      defmodule Username do
+        def sanitize('') do
+          ''
+        end
+
+        def sanitize([head | tail]) do
+          do_sanitize(head) ++ sanitize(tail)
+        end
+
+        defp do_sanitize(?ß), do: 'ss'
+        defp do_sanitize(?ä), do: 'ae'
+        defp do_sanitize(?ö), do: 'oe'
+        defp do_sanitize(?ü), do: 'ue'
+        defp do_sanitize(?_), do: '_'
+        defp do_sanitize(x) when x >= ?a and x <= ?z, do: [x]
+        defp do_sanitize(x), do: []
+      end
+    ]
+  end
+end


### PR DESCRIPTION
It checks that strings aren't used and that `case` is used.

Corresponding website copy PR: https://github.com/exercism/website-copy/pull/1992