### PR TITLE
Small refactor of exercise test suites

### DIFF
--- a/lib/elixir_analyzer/test_suite/bird_count.ex
+++ b/lib/elixir_analyzer/test_suite/bird_count.ex
@@ -79,7 +79,7 @@ defmodule ElixirAnalyzer.TestSuite.BirdCount do
 
   assert_no_call "doesn't use list comprehensions" do
     type :essential
-    called_fn name: :<-
+    called_fn name: :for
     comment ElixirAnalyzer.Constants.bird_count_use_recursion()
   end
 end

--- a/lib/elixir_analyzer/test_suite/boutique_suggestions.ex
+++ b/lib/elixir_analyzer/test_suite/boutique_suggestions.ex
@@ -7,7 +7,7 @@ defmodule ElixirAnalyzer.TestSuite.BoutiqueSuggestions do
 
   assert_call "uses list comprehensions" do
     type :essential
-    called_fn name: :<-
+    called_fn name: :for
     comment ElixirAnalyzer.Constants.boutique_suggestions_use_list_comprehensions()
   end
 

--- a/lib/elixir_analyzer/test_suite/take_a_number.ex
+++ b/lib/elixir_analyzer/test_suite/take_a_number.ex
@@ -17,55 +17,19 @@ defmodule ElixirAnalyzer.TestSuite.TakeANumber do
     end
 
     form do
-      Agent.start(_ignore)
-    end
-
-    form do
-      Agent.start(_ignore, _ignore)
-    end
-
-    form do
-      Agent.start(_ignore, _ignore, _ignore)
-    end
-
-    form do
-      Agent.start(_ignore, _ignore, _ignore, _ignore)
-    end
-
-    form do
-      Agent.start_link(_ignore)
-    end
-
-    form do
-      Agent.start_link(_ignore, _ignore)
-    end
-
-    form do
-      Agent.start_link(_ignore, _ignore, _ignore)
-    end
-
-    form do
-      Agent.start_link(_ignore, _ignore, _ignore, _ignore)
-    end
-
-    form do
       use GenServer
     end
+  end
 
-    form do
-      GenServer.start(_ignore, _ignore)
-    end
+  assert_no_call "doesn't call any Agent functions" do
+    type :essential
+    called_fn module: Agent, name: :_
+    comment ElixirAnalyzer.Constants.take_a_number_do_not_use_abstractions()
+  end
 
-    form do
-      GenServer.start(_ignore, _ignore, _ignore)
-    end
-
-    form do
-      GenServer.start_link(_ignore, _ignore)
-    end
-
-    form do
-      GenServer.start_link(_ignore, _ignore, _ignore)
-    end
+  assert_no_call "doesn't call any GenServer functions" do
+    type :essential
+    called_fn module: GenServer, name: :_
+    comment ElixirAnalyzer.Constants.take_a_number_do_not_use_abstractions()
   end
 end


### PR DESCRIPTION
This PR contains two small changes:
1. I realized looking for calls to `<-` is not only going to match list comprehensions, but also `with` expressions, so I changed it to `for`.
2. I shortened `TakeANumber` test suite by using `assert_no_call` instead of `form`.