### PR TITLE
Fix detecting default argument usage in guessing-game

### DIFF
--- a/lib/elixir_analyzer/test_suite/guessing_game.ex
+++ b/lib/elixir_analyzer/test_suite/guessing_game.ex
@@ -11,79 +11,7 @@ defmodule ElixirAnalyzer.TestSuite.GuessingGame do
     comment ElixirAnalyzer.Constants.guessing_game_use_guards()
 
     form do
-      def compare(_ignore, _ignore) when _ignore in _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore == _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore === _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore != _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore !== _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore > _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore < _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore < _ignore or _ignore > _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore > _ignore or _ignore < _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore >= _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore <= _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore >= _ignore or _ignore <= _ignore do
-        _ignore
-      end
-    end
-
-    form do
-      def compare(_ignore, _ignore) when _ignore <= _ignore or _ignore >= _ignore do
+      def compare(_ignore, _ignore) when _ignore do
         _ignore
       end
     end
@@ -100,6 +28,12 @@ defmodule ElixirAnalyzer.TestSuite.GuessingGame do
 
     form do
       def compare(_ignore, _ignore \\ :no_guess) do
+        _ignore
+      end
+    end
+
+    form do
+      def compare(_ignore, _ignore \\ :no_guess) when _ignore do
         _ignore
       end
     end

--- a/test/elixir_analyzer/test_suite/guessing_game_test.exs
+++ b/test/elixir_analyzer/test_suite/guessing_game_test.exs
@@ -101,6 +101,45 @@ defmodule ElixirAnalyzer.ExerciseTest.GuessingGameTest do
     ]
   end
 
+  test_exercise_analysis "detects technically correct but discouraged default argument without a function head",
+    comments_exclude: [Constants.guessing_game_use_default_argument()] do
+    [
+      defmodule GuessingGame do
+        def compare(_secret_number, guess \\ :no_guess) when guess == :no_guess do
+          "Make a guess"
+        end
+
+        def compare(secret_number, guess) when guess == secret_number do
+          "Correct"
+        end
+
+        # other cases
+      end,
+      defmodule GuessingGame do
+        def compare(_secret_number, :no_guess \\ :no_guess) do
+          "Make a guess"
+        end
+
+        def compare(secret_number, guess) when guess == secret_number do
+          "Correct"
+        end
+
+        # other cases
+      end,
+      defmodule GuessingGame do
+        # other cases
+
+        def compare(secret_number, guess) when guess < secret_number and is_integer(guess) do
+          "Too low"
+        end
+
+        def compare(_secret_number, guess \\ :no_guess) do
+          "Make a guess"
+        end
+      end
+    ]
+  end
+
   test_exercise_analysis "requires using multiple clause functions",
     comments_include: [Constants.guessing_game_use_multiple_clause_functions()],
     comments_exclude: [Constants.guessing_game_use_default_argument()] do


### PR DESCRIPTION
I witnessed a friend produce a solution that passed all of the tests but produced this warning:
```
warning: def compare/2 has multiple clauses and also declares default values. In such cases, the default values should be defined in a header. Instead of:

    def foo(:first_clause, b \\ :default) do ... end
    def foo(:second_clause, b) do ... end

one should write:

    def foo(a, b \\ :default)
    def foo(:first_clause, b) do ... end
    def foo(:second_clause, b) do ... end

```

The warning is not visible to the user. But what was visible, was a message from the analyzer that default arguments must be used - but they were already used.

This PR fixes that problem.

Additionally, I realized I don't have to write every possible guard. `def foo() when _ignore` will match all of them.