### PR TITLE
Change some moduledocs that have wrong descriptions

### DIFF
--- a/lib/elixir_analyzer/test_suite/guessing_game.ex
+++ b/lib/elixir_analyzer/test_suite/guessing_game.ex
@@ -1,6 +1,6 @@
 defmodule ElixirAnalyzer.TestSuite.GuessingGame do
   @moduledoc """
-  This is an exercise analyzer extension module for the concept exercise Bird Count
+  This is an exercise analyzer extension module for the concept exercise Guessing Game
   """
 
   use ElixirAnalyzer.ExerciseTest

--- a/lib/elixir_analyzer/test_suite/high_score.ex
+++ b/lib/elixir_analyzer/test_suite/high_score.ex
@@ -1,6 +1,6 @@
 defmodule ElixirAnalyzer.TestSuite.HighScore do
   @moduledoc """
-  This is an exercise analyzer extension module for the concept exercise Bird Count
+  This is an exercise analyzer extension module for the concept exercise High Score
   """
 
   use ElixirAnalyzer.ExerciseTest

--- a/lib/elixir_analyzer/test_suite/lasagna.ex
+++ b/lib/elixir_analyzer/test_suite/lasagna.ex
@@ -1,6 +1,6 @@
 defmodule ElixirAnalyzer.TestSuite.Lasagna do
   @moduledoc """
-  This is an exercise analyzer extension module for the concept exercise Take-A-Number
+  This is an exercise analyzer extension module for the concept exercise Lasagna
   """
 
   use ElixirAnalyzer.ExerciseTest


### PR DESCRIPTION
There are some modules that have a moduledoc  description a little wrong. For example, the following moduledoc is describing the Lasagna module.
```
@moduledoc """
  This is an exercise analyzer extension module for the concept exercise Take-A-Number
  """
```