### PR TITLE
[#103] Common check: module names in PascalCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This assumes the solution has the file of the proper name and also a test unit b
 
 At this time "two-fer" is the only solution implemented at a most basic level. All that gets validated is if it passes the test unit completely. Goal will be to able to recognize the optimal solution through ast search for specific patterns.
 
-As a demonstration, once iex loads with `iex -S mix` you can type `ElixirAnalyzer.analyze("two-fer", "./test_data/two_fer/passing_solution/", "./test_data/results/")`.
+As a demonstration, once iex loads with `iex -S mix` you can type `ElixirAnalyzer.analyze_exercise("two-fer", "./test_data/two_fer/passing_solution/", "./test_data/two_fer/passing_solution/")`.
 
 ## Design
 

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -19,7 +19,7 @@ defmodule ElixirAnalyzer.Constants do
     solution_use_specification: "elixir.solution.use_specification",
     solution_raise_fn_clause_error: "elixir.solution.raise_fn_clause_error",
     solution_module_attribute_name_snake_case: "elixir.solution.module_attribute_name_snake_case",
-    solution_module_pascal_case: "elixir.solution.module_name_pascal_case",
+    solution_module_pascal_case: "elixir.solution.module_pascal_case",
     solution_function_name_snake_case: "elixir.solution.function_name_snake_case",
 
     # Concept exercises

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -19,6 +19,7 @@ defmodule ElixirAnalyzer.Constants do
     solution_use_specification: "elixir.solution.use_specification",
     solution_raise_fn_clause_error: "elixir.solution.raise_fn_clause_error",
     solution_module_attribute_name_snake_case: "elixir.solution.module_attribute_name_snake_case",
+    solution_module_pascal_case: "elixir.solution.module_name_pascal_case",
     solution_function_name_snake_case: "elixir.solution.function_name_snake_case",
 
     # Concept exercises

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -5,13 +5,15 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
 
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionNames
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.ModuleAttributeNames
+  alias ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase
   alias ElixirAnalyzer.Comment
 
   @spec run(Macro.t(), String.t()) :: [{:pass | :fail | :skip, %Comment{}}]
   def run(code_ast, code_as_string) when is_binary(code_as_string) do
     [
       FunctionNames.run(code_ast),
-      ModuleAttributeNames.run(code_ast)
+      ModuleAttributeNames.run(code_ast),
+      ModulePascalCase.run(code_ast)
     ]
     |> List.flatten()
   end

--- a/lib/elixir_analyzer/exercise_test/common_checks/module_pascal_case.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/module_pascal_case.ex
@@ -17,8 +17,8 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase do
     wrong_name = List.last(names)
 
     if wrong_name do
-      wrong_name = to_string(wrong_name)
-      correct_name = to_pascal_case(wrong_name)
+      correct_name = Enum.map_join(wrong_name, ".", fn n -> n |> to_string |> to_pascal_case end)
+      wrong_name = Enum.map_join(wrong_name, ".", &to_string/1)
 
       [
         {:fail,
@@ -36,19 +36,11 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase do
     end
   end
 
-  defp traverse({:defmodule, _meta, [{:__aliases__, _meta2, [name]}, _do]} = ast, names) do
-    if pascal_case?(name) do
-      {ast, names}
+  defp traverse({:defmodule, _meta, [{:__aliases__, _meta2, names}, _do]} = ast, wrong_names) do
+    if Enum.all?(names, &pascal_case?/1) do
+      {ast, wrong_names}
     else
-      {ast, [name | names]}
-    end
-  end
-
-  defp traverse({:defmodule, _meta, [{name, _meta2, _nil}, _do]} = ast, names) do
-    if pascal_case?(name) do
-      {ast, names}
-    else
-      {ast, [name | names]}
+      {ast, [names | wrong_names]}
     end
   end
 

--- a/lib/elixir_analyzer/exercise_test/common_checks/module_pascal_case.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/module_pascal_case.ex
@@ -1,0 +1,69 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase do
+  @moduledoc """
+  Report the first defined module names that is not in PascalCase 
+
+  Doesn't report more if there are more.
+  A single comment should be enough for the student to know what to fix.
+
+  Common check to be run on every single solution.
+  """
+
+  alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.Comment
+
+  @spec run(Macro.t()) :: [{:pass | :fail | :skip, %Comment{}}]
+  def run(ast) do
+    {_, names} = Macro.prewalk(ast, [], &traverse/2)
+    wrong_name = List.last(names)
+
+    if wrong_name do
+      wrong_name = to_string(wrong_name)
+      correct_name = to_pascal_case(wrong_name)
+
+      [
+        {:fail,
+         %Comment{
+           type: :actionable,
+           comment: Constants.solution_module_pascal_case(),
+           params: %{
+             expected: correct_name,
+             actual: wrong_name
+           }
+         }}
+      ]
+    else
+      []
+    end
+  end
+
+  defp traverse({:defmodule, _meta, [{:__aliases__, _meta2, [name]}, _do]} = ast, names) do
+    if pascal_case?(name) do
+      {ast, names}
+    else
+      {ast, [name | names]}
+    end
+  end
+
+  defp traverse({:defmodule, _meta, [{name, _meta2, _nil}, _do]} = ast, names) do
+    if pascal_case?(name) do
+      {ast, names}
+    else
+      {ast, [name | names]}
+    end
+  end
+
+  defp traverse(ast, names) do
+    {ast, names}
+  end
+
+  defp pascal_case?(name) do
+    # the code had to compile and pass all the tests to get to the analyzer
+    # so we can assume the name is otherwise valid
+    to_pascal_case(name) == to_string(name)
+  end
+
+  defp to_pascal_case(name) do
+    # Macro.camelize is good enough because a module attribute name must be a valid Elixir identifier anyway
+    Macro.camelize(to_string(name))
+  end
+end

--- a/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
@@ -35,7 +35,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
   test "returns an actionable comment with params" do
     code =
       quote do
-        defmodule factorial do
+        defmodule Factorial_module do
         end
       end
 
@@ -45,8 +45,8 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
                 type: :actionable,
                 comment: Constants.solution_module_pascal_case(),
                 params: %{
-                  expected: "Factorial",
-                  actual: "factorial"
+                  expected: "FactorialModule",
+                  actual: "Factorial_module"
                 }
               }}
            ]
@@ -55,8 +55,8 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
   test "only reports the first module name" do
     code =
       quote do
-        defmodule factorial do
-          defmodule factorial_submodule do
+        defmodule Factorial_module do
+          defmodule Factorial_submodule do
             defstruct :!
           end
         end
@@ -68,8 +68,8 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
                 type: :actionable,
                 comment: Constants.solution_module_pascal_case(),
                 params: %{
-                  expected: "Factorial",
-                  actual: "factorial"
+                  expected: "FactorialModule",
+                  actual: "Factorial_module"
                 }
               }}
            ]
@@ -79,7 +79,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
     code =
       quote do
         defmodule Factorial do
-          defmodule factorial_submodule do
+          defmodule Factorial_submodule do
             defstruct :!
           end
         end
@@ -92,7 +92,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
                 comment: Constants.solution_module_pascal_case(),
                 params: %{
                   expected: "FactorialSubmodule",
-                  actual: "factorial_submodule"
+                  actual: "Factorial_submodule"
                 }
               }}
            ]

--- a/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
@@ -1,0 +1,100 @@
+# credo:disable-for-this-file Credo.Check.Readability.ModuleNames
+
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
+  use ExUnit.Case
+  alias ElixirAnalyzer.Comment
+  alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase
+
+  test "returns empty list if there are no module definition" do
+    code =
+      quote do
+        def calculate(1), do: 1
+
+        def calculate(n) do
+          n * calculate(n - 1)
+        end
+      end
+
+    assert ModulePascalCase.run(code) == []
+  end
+
+  test "returns empty list if there are no module names not in PascalCase" do
+    code =
+      quote do
+        defmodule Factorial do
+          defmodule FactorialSubmodule do
+            defstruct :!
+          end
+        end
+      end
+
+    assert ModulePascalCase.run(code) == []
+  end
+
+  test "returns an actionable comment with params" do
+    code =
+      quote do
+        defmodule factorial do
+        end
+      end
+
+    assert ModulePascalCase.run(code) == [
+             {:fail,
+              %Comment{
+                type: :actionable,
+                comment: Constants.solution_module_pascal_case(),
+                params: %{
+                  expected: "Factorial",
+                  actual: "factorial"
+                }
+              }}
+           ]
+  end
+
+  test "only reports the first module name" do
+    code =
+      quote do
+        defmodule factorial do
+          defmodule factorial_submodule do
+            defstruct :!
+          end
+        end
+      end
+
+    assert ModulePascalCase.run(code) == [
+             {:fail,
+              %Comment{
+                type: :actionable,
+                comment: Constants.solution_module_pascal_case(),
+                params: %{
+                  expected: "Factorial",
+                  actual: "factorial"
+                }
+              }}
+           ]
+  end
+
+  test "reports the inner module name" do
+    code =
+      quote do
+        defmodule Factorial do
+          defmodule factorial_submodule do
+            defstruct :!
+          end
+        end
+      end
+
+    assert ModulePascalCase.run(code) == [
+             {:fail,
+              %Comment{
+                type: :actionable,
+                comment: Constants.solution_module_pascal_case(),
+                params: %{
+                  expected: "FactorialSubmodule",
+                  actual: "factorial_submodule"
+                }
+              }}
+           ]
+  end
+end

--- a/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
@@ -97,4 +97,46 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
               }}
            ]
   end
+  
+  test "reports a module name with many segments" do
+    code =
+      quote do
+        defmodule MyLibrary.Math_ops.Factorial do
+        end
+      end
+
+    assert ModulePascalCase.run(code) == [
+             {:fail,
+               %Comment{
+                 type: :actionable,
+                 comment: Constants.solution_module_pascal_case(),
+                 params: %{
+                   expected: "MyLibrary.MathOps.Factorial",
+                   actual: "MyLibrary.Math_ops.Factorial"
+                 }
+               }}
+           ]
+  end
+
+  test "reports an inner module name with many segments" do
+    code =
+      quote do
+        defmodule MyLibrary do
+          defmodule Math_ops.Factorial do
+          end
+        end
+      end
+
+    assert ModulePascalCase.run(code) == [
+             {:fail,
+               %Comment{
+                 type: :actionable,
+                 comment: Constants.solution_module_pascal_case(),
+                 params: %{
+                   expected: "MathOps.Factorial",
+                   actual: "Math_ops.Factorial"
+                 }
+               }}
+           ]
+  end
 end

--- a/test/elixir_analyzer/exercise_test/common_checks_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks_test.exs
@@ -146,6 +146,10 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecksTest do
 
           defmodule SomeOtherSubModule do
           end
+        end,
+        defmodule Some.Module do
+          defmodule Some.Sub.Module do
+          end
         end
       ]
     end
@@ -157,14 +161,20 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecksTest do
           nil
         end,
         defmodule SomeModule do
-          defmodule someSubModule do
+          defmodule Some_subModule do
           end
         end,
         defmodule SomeModule do
           defmodule SomeSubModule do
           end
 
-          defmodule someOtherSubModule do
+          defmodule Some_otherSubModule do
+          end
+        end,
+        defmodule Some.Sub_module do
+        end,
+        defmodule Some.Module do
+          defmodule Some.Sub_module do
           end
         end
       ]

--- a/test/elixir_analyzer/exercise_test/common_checks_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks_test.exs
@@ -150,7 +150,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecksTest do
       ]
     end
 
-    test_exercise_analysis "reports a module attribute that doesn't use snake_case",
+    test_exercise_analysis "reports a module attribute that doesn't use PascalCase",
       comments_include: [Constants.solution_module_pascal_case()] do
       [
         defmodule Some_module do

--- a/test/elixir_analyzer/exercise_test/common_checks_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks_test.exs
@@ -1,5 +1,6 @@
 # credo:disable-for-this-file Credo.Check.Readability.ModuleAttributeNames
 # credo:disable-for-this-file Credo.Check.Readability.FunctionNames
+# credo:disable-for-this-file Credo.Check.Readability.ModuleNames
 
 defmodule ElixirAnalyzer.ExerciseTestTest.Empty do
   use ElixirAnalyzer.ExerciseTest
@@ -123,6 +124,48 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecksTest do
         end,
         defmodule SomeModule do
           @someValue 3
+        end
+      ]
+    end
+  end
+
+  describe "module names in PascalCase" do
+    test_exercise_analysis "doesn't report correct module names",
+      comments_exclude: [Constants.solution_module_pascal_case()] do
+      [
+        defmodule SomeModule do
+          nil
+        end,
+        defmodule SomeModule do
+          defmodule SomeSubModule do
+          end
+        end,
+        defmodule SomeModule do
+          defmodule SomeSubModule do
+          end
+
+          defmodule SomeOtherSubModule do
+          end
+        end
+      ]
+    end
+
+    test_exercise_analysis "reports a module attribute that doesn't use snake_case",
+      comments_include: [Constants.solution_module_pascal_case()] do
+      [
+        defmodule Some_module do
+          nil
+        end,
+        defmodule SomeModule do
+          defmodule someSubModule do
+          end
+        end,
+        defmodule SomeModule do
+          defmodule SomeSubModule do
+          end
+
+          defmodule someOtherSubModule do
+          end
         end
       ]
     end

--- a/test/elixir_analyzer_test.exs
+++ b/test/elixir_analyzer_test.exs
@@ -29,7 +29,7 @@ defmodule ElixirAnalyzerTest do
       analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, path, @options)
 
       expected_output = """
-      {\"comments\":[{\"comment\":\"elixir.solution.use_module_doc\",\"type\":\"informative\"},{\"comment\":\"elixir.solution.raise_fn_clause_error\",\"type\":\"actionable\"},{\"comment\":\"elixir.two-fer.use_of_function_header\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_specification\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
+      {\"comments\":[{\"comment\":\"elixir.solution.use_module_doc\",\"type\":\"informative\"},{\"comment\":\"elixir.solution.raise_fn_clause_error\",\"type\":\"actionable\"},{\"comment\":\"elixir.two-fer.use_of_function_header\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_specification\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_name_pascal_case\",\"params\":{\"actual\":\"my_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
       """
 
       assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)
@@ -71,7 +71,7 @@ defmodule ElixirAnalyzerTest do
         analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, path, @options)
 
         expected_output = """
-        {\"comments\":[{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
+        {\"comments\":[{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_name_pascal_case\",\"params\":{\"actual\":\"my_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
         """
 
         assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)

--- a/test/elixir_analyzer_test.exs
+++ b/test/elixir_analyzer_test.exs
@@ -29,7 +29,7 @@ defmodule ElixirAnalyzerTest do
       analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, path, @options)
 
       expected_output = """
-      {\"comments\":[{\"comment\":\"elixir.solution.use_module_doc\",\"type\":\"informative\"},{\"comment\":\"elixir.solution.raise_fn_clause_error\",\"type\":\"actionable\"},{\"comment\":\"elixir.two-fer.use_of_function_header\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_specification\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_name_pascal_case\",\"params\":{\"actual\":\"My_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
+      {\"comments\":[{\"comment\":\"elixir.solution.use_module_doc\",\"type\":\"informative\"},{\"comment\":\"elixir.solution.raise_fn_clause_error\",\"type\":\"actionable\"},{\"comment\":\"elixir.two-fer.use_of_function_header\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_specification\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_pascal_case\",\"params\":{\"actual\":\"My_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
       """
 
       assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)
@@ -71,7 +71,7 @@ defmodule ElixirAnalyzerTest do
         analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, path, @options)
 
         expected_output = """
-        {\"comments\":[{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_name_pascal_case\",\"params\":{\"actual\":\"My_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
+        {\"comments\":[{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_pascal_case\",\"params\":{\"actual\":\"My_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
         """
 
         assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)

--- a/test/elixir_analyzer_test.exs
+++ b/test/elixir_analyzer_test.exs
@@ -29,7 +29,7 @@ defmodule ElixirAnalyzerTest do
       analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, path, @options)
 
       expected_output = """
-      {\"comments\":[{\"comment\":\"elixir.solution.use_module_doc\",\"type\":\"informative\"},{\"comment\":\"elixir.solution.raise_fn_clause_error\",\"type\":\"actionable\"},{\"comment\":\"elixir.two-fer.use_of_function_header\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_specification\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_name_pascal_case\",\"params\":{\"actual\":\"my_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
+      {\"comments\":[{\"comment\":\"elixir.solution.use_module_doc\",\"type\":\"informative\"},{\"comment\":\"elixir.solution.raise_fn_clause_error\",\"type\":\"actionable\"},{\"comment\":\"elixir.two-fer.use_of_function_header\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_specification\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_name_pascal_case\",\"params\":{\"actual\":\"My_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
       """
 
       assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)
@@ -71,7 +71,7 @@ defmodule ElixirAnalyzerTest do
         analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, path, @options)
 
         expected_output = """
-        {\"comments\":[{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_name_pascal_case\",\"params\":{\"actual\":\"my_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
+        {\"comments\":[{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_name_pascal_case\",\"params\":{\"actual\":\"My_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
         """
 
         assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)

--- a/test_data/two_fer/imperfect_solution/lib/two_fer.ex
+++ b/test_data/two_fer/imperfect_solution/lib/two_fer.ex
@@ -1,7 +1,7 @@
 defmodule TwoFer do
   @someUnusedModuleAttribute 1
 
-  defmodule my_empty_module do
+  defmodule My_empty_module do
   end
 
   @doc """

--- a/test_data/two_fer/imperfect_solution/lib/two_fer.ex
+++ b/test_data/two_fer/imperfect_solution/lib/two_fer.ex
@@ -1,20 +1,17 @@
 defmodule TwoFer do
   @someUnusedModuleAttribute 1
 
+  defmodule my_empty_module do
+  end
+
   @doc """
   Two-fer or 2-fer is short for two for one. One for you and one for me.
   """
   def two_fer(name \\ "you")
+
   def two_fer(name) when is_binary(name) do
     "One for #{name}, one for me"
   end
-  def two_fer(_name), do: raise FunctionClauseError
+
+  def two_fer(_name), do: raise(FunctionClauseError)
 end
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Solves #103.

First try with the analyzer, so I'm not sure I got everything right. Is there something else I should run ti check the PR besides `mix test`?

I noticed at the end that Credo calls this check `ModuleName` and I called it `ModulePascalCase`. Is that OK?

Sorry I couldn't review the previous PR, family time comes first :)