### PR TITLE
Fix variable name check reporting function names

### DIFF
--- a/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
@@ -97,7 +97,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
               }}
            ]
   end
-  
+
   test "reports a module name with many segments" do
     code =
       quote do
@@ -107,14 +107,14 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
 
     assert ModulePascalCase.run(code) == [
              {:fail,
-               %Comment{
-                 type: :actionable,
-                 comment: Constants.solution_module_pascal_case(),
-                 params: %{
-                   expected: "MyLibrary.MathOps.Factorial",
-                   actual: "MyLibrary.Math_ops.Factorial"
-                 }
-               }}
+              %Comment{
+                type: :actionable,
+                comment: Constants.solution_module_pascal_case(),
+                params: %{
+                  expected: "MyLibrary.MathOps.Factorial",
+                  actual: "MyLibrary.Math_ops.Factorial"
+                }
+              }}
            ]
   end
 
@@ -129,14 +129,14 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
 
     assert ModulePascalCase.run(code) == [
              {:fail,
-               %Comment{
-                 type: :actionable,
-                 comment: Constants.solution_module_pascal_case(),
-                 params: %{
-                   expected: "MathOps.Factorial",
-                   actual: "Math_ops.Factorial"
-                 }
-               }}
+              %Comment{
+                type: :actionable,
+                comment: Constants.solution_module_pascal_case(),
+                params: %{
+                  expected: "MathOps.Factorial",
+                  actual: "Math_ops.Factorial"
+                }
+              }}
            ]
   end
 end

--- a/test/elixir_analyzer/exercise_test/common_checks/variable_names_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/variable_names_test.exs
@@ -423,4 +423,45 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
              ]
     end
   end
+
+  describe "unrelated code" do
+    test "it should NOT report function names" do
+      code =
+        quote do
+          defmodule User do
+            def firstName(user), do: user.first_name
+            defp registeredInLastQuarter?(user), do: true
+            defmacro validateUser!(user), do: true
+            defmacrop doValidateUser(user), do: true
+          end
+        end
+
+      assert VariableNames.run(code) == []
+    end
+
+    test "it should NOT report function names when no arg and missing parenthesis" do
+      code =
+        quote do
+          defmodule User do
+            def firstName, do: nil
+            defp registeredInLastQuarter?, do: true
+            defmacro validateUser!, do: true
+            defmacrop doValidateUser, do: true
+          end
+        end
+
+      assert VariableNames.run(code) == []
+    end
+
+    test "it should NOT report module attribute names" do
+      code =
+        quote do
+          defmodule CredoSampleModule do
+            @someModuleAttribute 7
+          end
+        end
+
+      assert VariableNames.run(code) == []
+    end
+  end
 end

--- a/test/elixir_analyzer/exercise_test/common_checks/variable_names_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/variable_names_test.exs
@@ -1,4 +1,6 @@
 # credo:disable-for-this-file Credo.Check.Readability.VariableNames
+# credo:disable-for-this-file Credo.Check.Readability.FunctionNames
+# credo:disable-for-this-file Credo.Check.Readability.ModuleAttributeNames
 
 defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
   use ExUnit.Case


### PR DESCRIPTION
I discovered this issue accidentally by playing around. Apparently a function definition without parenthesis produces a different AST then exactly the same function definition with parenthesis:

```elixir
iex(1)> x = quote do
...(1)> def foo, do: nil
...(1)> end
{:def, [context: Elixir, import: Kernel],
 [{:foo, [context: Elixir], Elixir}, [do: nil]]}

iex(2)> y = quote do
...(2)> def foo(), do: nil
...(2)> end
{:def, [context: Elixir, import: Kernel],
 [{:foo, [context: Elixir], []}, [do: nil]]}
```

I don't know how to fix this yet... I opened a PR with failing tests as a reminder.