### PR TITLE
[#91] Write analysis for concept exercise `rpg-character-sheet`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -57,6 +57,9 @@ config :elixir_analyzer,
     "name-badge" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.NameBadge
     },
+    "rpg-character-sheet" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.RpgCharacterSheet
+    },
     "rpn-calculator-output" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.RpnCalculatorOutput
     },

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -95,3 +95,22 @@ feature "description" do
   end
 end
 ```
+
+## Asserting that a block finished with a specific function 
+
+This check will also pass if there are other function calls in between or before (bot not after). When used to match a single line, make sure to place `_block_ends_with` inside a context (like a module or function definition) as in the example below.
+
+```elixir
+feature "description" do
+  find :any
+
+  form do
+    def read_file(_ignore) do
+      _block_ends_with do
+        _ignore = File.open(_ignore)
+        File.close(_ignore)
+      end
+    end
+  end
+end
+```

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -98,7 +98,7 @@ end
 
 ## Asserting that a block finished with a specific function 
 
-This check will also pass if there are other function calls in between or before (bot not after). When used to match a single line, make sure to place `_block_ends_with` inside a context (like a module or function definition) as in the example below.
+This check will also pass if there are other function calls in between or before (but not after). When used to match a single line, make sure to place `_block_ends_with` inside a context (like a module or function definition) as in the example below.
 
 ```elixir
 feature "description" do

--- a/docs/step-03/step-03.md
+++ b/docs/step-03/step-03.md
@@ -177,8 +177,79 @@ form do
 end
 ```
 
+##### 2.2 The `_block_ends_with` feature
 
-##### 2.2 Limitations
+The `_block_ends_with` feature is very similar to `_block_includes`, the only difference is that the last line of `_block_ends_with` must match the last line of the code being matched.
+
+For example, the following feature
+
+```elixir
+feature "opens and closes the resource" do
+  form do
+    _block_ends_with do
+      _ignore = open(resource)
+      close(resource)
+    end
+  end
+end
+
+```
+
+will match the following function
+
+```elixir
+def write(resource, content) do
+  pipe = open(resource)
+  dump_content(pipe, content)
+  |> flush()
+  close(resource)
+end
+```
+
+but would not match the `_block_includes` example above ending with `:ok`.
+
+`_block_ends_with` also consumes all the lines of a block of code, so it cannot be used right before or after another match, just like `_block_includes`.
+
+Additionally, when trying to match a single line, if `_block_includes` is not placed within a context (module, function...) the line will match even if it's not the last in the code.
+
+For example
+
+```elixir
+# do not use _block_ends_with in this way
+form do
+  # No context given, _block_ends_with will attempt to match line by line
+  _block_ends_with do
+    close(resource)
+  end
+end
+```
+
+will match
+
+```elixir
+def write(resource, content) do
+  pipe = open(resource)
+  dump_content(pipe, content)
+  |> flush()
+  close(resource)
+  :ok
+end
+```
+
+Instead, use
+
+```elixir
+form do
+  def write(_ignore, _ignore) do
+    _block_ends_with do
+      close(resource)
+    end
+  end
+end
+```
+
+
+##### 2.3 Limitations
 
 Slightly different syntax can produce exactly the same AST. That means that certain details cannot be distinguished by this analyzer. If they cannot be distinguished, they cannot be verified by the analyzer, but they also don't need to be both listed when specifying all of the forms for a feature.
 

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -68,6 +68,16 @@ defmodule ElixirAnalyzer.Constants do
     need_for_speed_import_IO_with_only: "elixir.need-for-speed.import_IO_with_only",
     need_for_speed_import_ANSI_with_except: "elixir.need-for-speed.import_ANSI_with_except",
     need_for_speed_do_not_modify_code: "elixir.need-for-speed.do_not_modify_code",
+
+    # RPG Character Sheet
+    rpg_character_sheet_welcome_ends_with_IO_puts:
+      "elixir.rpg-character-sheet.welcome_ends_with_IO_puts",
+    rpg_character_sheet_run_uses_other_functions:
+      "elixir.rpg-character-sheet.run_uses_other_functions",
+    rpg_character_sheet_run_ends_with_IO_inspect:
+      "elixir.rpg-character-sheet.ends_with_IO_inspect",
+    rpg_character_sheet_IO_inspect_uses_label: "elixir.rpg-character-sheet.IO_inspect_uses_label",
+
     # RPN Calculator Output
     rpn_calculator_output_try_rescue_else_after:
       "elixir.rpn-calculator-output.try_rescue_else_after",

--- a/lib/elixir_analyzer/exercise_test/feature/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/feature/compiler.ex
@@ -201,6 +201,30 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.Compiler do
     end
   end
 
+  def form_match?(
+        {:_block_ends_with, _, [[do: {:__block__, _, form_params}]]},
+        {:__block__, _, params}
+      ) do
+    form_match?(List.last(form_params), List.last(params)) and
+      all_forms_are_found?(form_params, params)
+  end
+
+  def form_match?({:_block_ends_with, _, [[do: form_params]]}, params)
+      when is_list(form_params) do
+    form_match?(List.last(form_params), List.last(List.wrap(params))) and
+      all_forms_are_found?(form_params, params)
+  end
+
+  def form_match?({:_block_ends_with, _, [[do: form_params]]}, params) do
+    case params do
+      {:__block__, _, block_params} ->
+        form_match?(form_params, List.last(block_params))
+
+      _ ->
+        form_match?(form_params, List.last(List.wrap(params)))
+    end
+  end
+
   def form_match?(form_params, params) when is_list(form_params) and is_list(params) do
     length(form_params) == length(params) and
       Enum.zip_with(form_params, params, &form_match?/2)

--- a/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
+++ b/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
@@ -1,0 +1,89 @@
+defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheet do
+  @moduledoc """
+  This is an exercise analyzer extension module for the concept exercise rpg-character-sheet
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
+
+  feature "welcome ends with IO.puts" do
+    type :essential
+    find :all
+    depth 1
+    comment Constants.rpg_character_sheet_welcome_ends_with_IO_puts()
+
+    form do
+      def welcome() do
+        _block_ends_with do
+          IO.puts(_ignore)
+        end
+      end
+    end
+  end
+
+  assert_call "run uses welcome" do
+    type :essential
+    called_fn name: :welcome
+    calling_fn module: RPG.CharacterSheet, name: :run
+    comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
+  end
+
+  assert_call "run uses ask_name" do
+    type :essential
+    called_fn name: :ask_name
+    calling_fn module: RPG.CharacterSheet, name: :run
+    comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
+  end
+
+  assert_call "run uses ask_class" do
+    type :essential
+    called_fn name: :ask_class
+    calling_fn module: RPG.CharacterSheet, name: :run
+    comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
+  end
+
+  assert_call "run uses ask_level" do
+    type :essential
+    called_fn name: :ask_level
+    calling_fn module: RPG.CharacterSheet, name: :run
+    comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
+  end
+
+  feature "run ends with IO.inspect" do
+    type :essential
+    find :one
+    depth 1
+    comment Constants.rpg_character_sheet_run_ends_with_IO_inspect()
+
+    form do
+      def run() do
+        _block_ends_with do
+          IO.inspect(_ignore)
+        end
+      end
+    end
+
+    form do
+      def run() do
+        _block_ends_with do
+          IO.inspect(_ignore, _ignore)
+        end
+      end
+    end
+  end
+
+  feature "IO.inspect uses the :label option" do
+    type :essential
+    find :all
+    depth 1
+    comment Constants.rpg_character_sheet_IO_inspect_uses_label()
+
+    form do
+      def run() do
+        _block_includes do
+          IO.inspect(_ignore, label: _ignore)
+        end
+      end
+    end
+  end
+end

--- a/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
+++ b/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
@@ -8,7 +8,7 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheet do
 
   feature "welcome ends with IO.puts" do
     type :actionable
-    find :all
+    find :any
     depth 1
     comment Constants.rpg_character_sheet_welcome_ends_with_IO_puts()
 
@@ -16,6 +16,14 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheet do
       def welcome() do
         _block_ends_with do
           IO.puts(_ignore)
+        end
+      end
+    end
+
+    form do
+      def welcome() do
+        _block_ends_with do
+          IO.write(_ignore)
         end
       end
     end

--- a/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
+++ b/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
@@ -7,7 +7,7 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheet do
   alias ElixirAnalyzer.Constants
 
   feature "welcome ends with IO.puts" do
-    type :essential
+    type :actionable
     find :all
     depth 1
     comment Constants.rpg_character_sheet_welcome_ends_with_IO_puts()
@@ -22,28 +22,28 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheet do
   end
 
   assert_call "run uses welcome" do
-    type :essential
+    type :actionable
     called_fn name: :welcome
     calling_fn module: RPG.CharacterSheet, name: :run
     comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
   end
 
   assert_call "run uses ask_name" do
-    type :essential
+    type :actionable
     called_fn name: :ask_name
     calling_fn module: RPG.CharacterSheet, name: :run
     comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
   end
 
   assert_call "run uses ask_class" do
-    type :essential
+    type :actionable
     called_fn name: :ask_class
     calling_fn module: RPG.CharacterSheet, name: :run
     comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
   end
 
   assert_call "run uses ask_level" do
-    type :essential
+    type :actionable
     called_fn name: :ask_level
     calling_fn module: RPG.CharacterSheet, name: :run
     comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()

--- a/test/elixir_analyzer/exercise_test/feature/block_ends_with_test.exs
+++ b/test/elixir_analyzer/exercise_test/feature/block_ends_with_test.exs
@@ -1,0 +1,477 @@
+defmodule ElixirAnalyzer.ExerciseTest.Feature.BlockEndsWithTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.Support.AnalyzerVerification.Feature.BlockEndsWith
+
+  describe "finding a single expression" do
+    test_exercise_analysis "code with an :ok in it",
+      comments_exclude: ["cannot detect :ok"] do
+      [
+        defmodule MyModule do
+          def foo() do
+            :ok
+          end
+        end,
+        defmodule MyModule do
+          def foo() do
+            x = "hi"
+            :ok
+          end
+        end,
+        defmodule MyModule do
+          def foo(:ok) do
+            IO.puts("hello")
+          end
+        end,
+        defmodule MyModule do
+          def foo() do
+            case {} do
+              _ -> :ok
+            end
+          end
+        end,
+        defmodule MyModule do
+          def foo() when :ok do
+            true
+          end
+        end,
+        defmodule MyModule do
+          def foo() do
+            :ok.lets_pretend_this_is_an_erlang_module()
+            # Erlang function call counts as atom literal
+          end
+        end,
+        defmodule MyModule do
+          def foo() do
+            :ok
+            # Atoms are always found, even when they are not the last
+            :nope
+          end
+        end
+      ]
+    end
+
+    test_exercise_analysis "code not finishing by :ok",
+      comments_include: ["cannot detect :ok"] do
+      [
+        defmodule MyModule do
+          def foo() do
+            :error
+          end
+        end,
+        defmodule MyModule do
+          def foo() do
+            :ok_nope
+          end
+        end,
+        defmodule MyModule do
+          def ok() do
+            # function name does not count as atom literal
+          end
+        end,
+        defmodule MyModule do
+          def foo() do
+            ok()
+            # function call doesn't count as atom literal
+          end
+        end
+      ]
+    end
+  end
+
+  test_exercise_analysis "code ending with two lines",
+    comments_exclude: ["cannot detect two lines"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          name = "Bob"
+          greeting = "hi #{name}"
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          something = :before
+          name = "Bob"
+          something = :between
+          greeting = "hi #{name}"
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          cond do
+            false ->
+              name = "Bob"
+              greeting = "hi #{name}"
+
+            true ->
+              name = "Eve"
+
+            nil ->
+              name = "Alice"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          if nil do
+            name = "Bob"
+            greeting = "hi #{name}"
+          else
+            name = "Eve"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          name = "Bob"
+          name = "Bob"
+          name = "Bob"
+          greeting = "hi #{name}"
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          # Duplicated last line is OK because it is still the same
+          name = "Bob"
+          name = "Bob"
+          greeting = "hi #{name}"
+          greeting = "hi #{name}"
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "code not ending with the two lines",
+    comments_include: ["cannot detect two lines"] do
+    [
+      defmodule MyModule do
+        def foo() do
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          # Not the last
+          name = "Bob"
+          greeting = "hi #{name}"
+          something = :else
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          # Wrong order
+          greeting = "hi #{name}"
+          name = "Bob"
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          cond do
+            # In different blocks
+            false ->
+              name = "Bob"
+
+            true ->
+              greeting = "hi #{name}"
+
+            :truthy ->
+              :ok
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          if nil do
+            name = "Bob"
+          else
+            greeting = "hi #{name}"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          name = "Bob"
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          greeting = "hi #{name}"
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "code ending with pattern matches",
+    comments_exclude: ["cannot detect pattern matches"] do
+    [
+      defmodule MyModule do
+        def foo(thing) do
+          case thing do
+            :ok -> "All good"
+            _ -> "Whoops"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo(thing) do
+          case thing do
+            :ok -> "All good"
+            :err -> "Error"
+            _ -> "Whoops"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo(thing) do
+          case thing do
+            :ok -> "All good"
+            :ok -> "All good"
+            :err -> "Error"
+            _ -> "Whoops"
+            :err -> "Error"
+            _ -> "Whoops"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo(thing) do
+          cond do
+            :ok -> "All good"
+            is_nil(thing) -> "No good"
+            is_list(thing) -> "Not applicable"
+            _ -> "Whoops"
+          end
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "code not ending with pattern matches",
+    comments_include: ["cannot detect pattern matches"] do
+    [
+      defmodule MyModule do
+        def foo(thing) do
+          case thing do
+            :ok -> "All good"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo(thing) do
+          case thing do
+            _ -> "Whoops"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo(thing) do
+          case thing do
+            # Wrong order
+            _ -> "Whoops"
+            :ok -> "All good"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo(thing) do
+          case thing do
+            # Not the last
+            :ok -> "All good"
+            _ -> "Whoops"
+            :err -> "Error"
+          end
+        end
+      end,
+      defmodule MyModule do
+        def foo(thing) do
+          cond do
+            :ok -> "All good"
+            is_nil(thing) -> "No good"
+          end
+
+          cond do
+            is_list(thing) -> "Not applicable"
+            is_nil(thin) -> "Even worse"
+            _ -> "Whoops"
+          end
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "code ending with functions",
+    comments_exclude: ["cannot detect functions"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          :ok
+        end
+
+        def bar(baz) do
+          {:err, baz}
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+        end
+
+        def bar(baz) do
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          IO.puts("!")
+        end
+
+        def baz(_, _) do
+          :ok
+        end
+
+        def bar(_) do
+          :a
+          :b
+          :c
+        end
+      end,
+      defmodule MyModule do
+        def baz(_, _), do: :ok
+
+        def foo(), do: :hello
+
+        def bar(baz), do: :bye
+      end
+    ]
+  end
+
+  test_exercise_analysis "code not endinf with functions",
+    comments_include: ["cannot detect functions"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          :ok
+        end
+      end,
+      defmodule MyModule do
+        def bar(baz) do
+          {:err, baz}
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+        end
+
+        def bar(baz) do
+        end
+
+        def hi() do
+          :hello
+        end
+      end,
+      defmodule MyModule do
+        # wrong order
+        def bar(baz) do
+        end
+
+        def foo() do
+        end
+      end,
+      defmodule MyModule do
+        # one argument in foo
+        def foo(?!) do
+          IO.puts("!")
+        end
+
+        def bar(_) do
+          :a
+          :b
+          :c
+        end
+      end,
+      defmodule MyModule do
+        def foo(), do: :hello
+
+        # Missing argument
+        def bar(), do: :bye
+      end
+    ]
+  end
+
+  test_exercise_analysis "code with nested blocks",
+    comments_exclude: ["cannot detect nested blocks"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          name = "Bob"
+          greeting = "hi #{name}"
+        end
+      end,
+      defmodule MyModule do
+        def bar(baz) do
+          nil
+        end
+
+        def foo() do
+          age = 12
+          name = "Bob"
+          eyes = "Blue"
+          greeting = "hi #{name}"
+          greeting = "hi #{name}"
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "code without nested blocks",
+    comments_include: ["cannot detect nested blocks"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          name = "Bob"
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          name = "Bob"
+          greeting = "hi #{name}"
+        end
+
+        def baz() do
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+        end
+
+        def bar() do
+          age = 12
+          name = "Bob"
+          eyes = "Blue"
+          greeting = "hi #{name}"
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "a block matches a full block",
+    comments_exclude: ["could use two in a row", "could match a line and a block in a row"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          :hello
+          :goodbye
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "without context, a single line always matches",
+    comments_exclude: ["could not match a line"] do
+    [
+      defmodule MyModule do
+        def bar() do
+          # Not the last, but matches
+          foo(:ok)
+          x = 42
+        end
+      end
+    ]
+  end
+end

--- a/test/elixir_analyzer/exercise_test/feature/block_ends_with_test.exs
+++ b/test/elixir_analyzer/exercise_test/feature/block_ends_with_test.exs
@@ -462,14 +462,44 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.BlockEndsWithTest do
     ]
   end
 
-  test_exercise_analysis "without context, a single line always matches",
-    comments_exclude: ["could not match a line"] do
+  test_exercise_analysis "without context, :ok will match anywhere",
+    comments_exclude: ["without context: could not match a line"] do
     [
       defmodule MyModule do
-        def bar() do
-          # Not the last, but matches
-          foo(:ok)
+        def foo() do
+          # Not the last, but matches because foo() context was not provided
+          :ok
           x = 42
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "with context, :ok will be as expected",
+    comments_include: ["with context: could not match :ok"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          # Not the last, so doesn't match if foo() context is provided
+          :ok
+          x = 42
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "with context, :ok will be matched if last",
+    comments_exclude: ["with context: could not match :ok"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          x = 42
+          :ok
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          :ok
         end
       end
     ]

--- a/test/elixir_analyzer/exercise_test/feature/block_ends_with_test.exs
+++ b/test/elixir_analyzer/exercise_test/feature/block_ends_with_test.exs
@@ -341,7 +341,7 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.BlockEndsWithTest do
     ]
   end
 
-  test_exercise_analysis "code not endinf with functions",
+  test_exercise_analysis "code not ending with functions",
     comments_include: ["cannot detect functions"] do
     [
       defmodule MyModule do

--- a/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
+++ b/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
@@ -44,23 +44,43 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheetTest do
     end
   end
 
-  test_exercise_analysis "welcome doesn't end with IO.puts",
-    comments_include: [Constants.rpg_character_sheet_welcome_ends_with_IO_puts()] do
-    [
-      defmodule RPG.CharacterSheet do
-        def welcome() do
-          IO.puts("Welcome! Let's fill out your character sheet together.")
-          :ok
+  describe "implicit :ok return" do
+    test_exercise_analysis "ending with IO.write is not ideal, but allowed",
+      comments_exclude: [Constants.rpg_character_sheet_welcome_ends_with_IO_puts()] do
+      [
+        defmodule RPG.CharacterSheet do
+          def welcome() do
+            IO.write("Welcome! Let's fill out your character sheet together.\n")
+          end
         end
-      end,
-      defmodule RPG.CharacterSheet do
-        def welcome() do
-          text = "Welcome! Let's fill out your character sheet together."
-          IO.puts(text)
-          :ok
+      ]
+    end
+
+    test_exercise_analysis "welcome doesn't end with IO.puts or IO write",
+      comments_include: [Constants.rpg_character_sheet_welcome_ends_with_IO_puts()] do
+      [
+        defmodule RPG.CharacterSheet do
+          def welcome() do
+            IO.puts("Welcome! Let's fill out your character sheet together.")
+            :ok
+          end
+        end,
+        defmodule RPG.CharacterSheet do
+          def welcome() do
+            text = "Welcome! Let's fill out your character sheet together."
+            IO.puts(text)
+            :ok
+          end
+        end,
+        defmodule RPG.CharacterSheet do
+          def welcome() do
+            text = "Welcome! Let's fill out your character sheet together."
+            IO.write(text <> "\n")
+            :ok
+          end
         end
-      end
-    ]
+      ]
+    end
   end
 
   test_exercise_analysis "run doesn't reuse functions",

--- a/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
+++ b/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
@@ -1,0 +1,234 @@
+defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheetTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.TestSuite.RpgCharacterSheet
+
+  alias ElixirAnalyzer.Constants
+
+  test_exercise_analysis "example solution",
+    comments: [] do
+    defmodule RPG.CharacterSheet do
+      def welcome() do
+        IO.puts("Welcome! Let's fill out your character sheet together.")
+      end
+
+      def ask_name() do
+        name = IO.gets("What is your character's name?\n")
+        String.trim(name)
+      end
+
+      def ask_class() do
+        name = IO.gets("What is your character's class?\n")
+        String.trim(name)
+      end
+
+      def ask_level() do
+        level = IO.gets("What is your character's level?\n")
+        level = String.trim(level)
+        String.to_integer(level)
+      end
+
+      def run() do
+        welcome()
+        name = ask_name()
+        class = ask_class()
+        level = ask_level()
+
+        character = %{
+          name: name,
+          class: class,
+          level: level
+        }
+
+        IO.inspect(character, label: "Your character")
+      end
+    end
+  end
+
+  test_exercise_analysis "welcome doesn't end with IO.puts",
+    comments_include: [Constants.rpg_character_sheet_welcome_ends_with_IO_puts()] do
+    [
+      defmodule RPG.CharacterSheet do
+        def welcome() do
+          IO.puts("Welcome! Let's fill out your character sheet together.")
+          :ok
+        end
+      end,
+      defmodule RPG.CharacterSheet do
+        def welcome() do
+          text = "Welcome! Let's fill out your character sheet together."
+          IO.puts(text)
+          :ok
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "run doesn't reuse functions",
+    comments_include: [Constants.rpg_character_sheet_run_uses_other_functions()] do
+    [
+      defmodule RPG.CharacterSheet do
+        def run() do
+          IO.puts("Welcome! Let's fill out your character sheet together.")
+          name = ask_name()
+          class = ask_class()
+          level = ask_level()
+
+          character = %{
+            name: name,
+            class: class,
+            level: level
+          }
+
+          IO.inspect(character, label: "Your character")
+        end
+      end,
+      defmodule RPG.CharacterSheet do
+        def run() do
+          welcome()
+
+          name =
+            IO.gets("What is your character's name?\n")
+            |> String.trim()
+
+          class = ask_class()
+          level = ask_level()
+
+          character = %{
+            name: name,
+            class: class,
+            level: level
+          }
+
+          IO.inspect(character, label: "Your character")
+        end
+      end,
+      defmodule RPG.CharacterSheet do
+        def run() do
+          welcome()
+          name = ask_name()
+
+          class =
+            IO.gets("What is your character's class?\n")
+            |> String.trim()
+
+          level = ask_level()
+
+          character = %{
+            name: name,
+            class: class,
+            level: level
+          }
+
+          IO.inspect(character, label: "Your character")
+        end
+      end,
+      defmodule RPG.CharacterSheet do
+        def run() do
+          welcome()
+          name = ask_name()
+          class = ask_class()
+
+          level =
+            IO.gets("What is your character's level?\n")
+            |> String.trim()
+            |> String.to_integer()
+
+          character = %{
+            name: name,
+            class: class,
+            level: level
+          }
+
+          IO.inspect(character, label: "Your character")
+        end
+      end,
+      defmodule RPG.CharacterSheet do
+        def run() do
+          IO.puts("Welcome! Let's fill out your character sheet together.")
+
+          name =
+            IO.gets("What is your character's name?\n")
+            |> String.trim()
+
+          class =
+            IO.gets("What is your character's class?\n")
+            |> String.trim()
+
+          level =
+            IO.gets("What is your character's level?\n")
+            |> String.trim()
+            |> String.to_integer()
+
+          character = %{
+            name: name,
+            class: class,
+            level: level
+          }
+
+          IO.inspect(character, label: "Your character")
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "run doesn't end with IO.inspect",
+    comments_include: [Constants.rpg_character_sheet_run_ends_with_IO_inspect()] do
+    [
+      defmodule RPG.CharacterSheet do
+        def run() do
+          welcome()
+          name = ask_name()
+          class = ask_class()
+          level = ask_level()
+
+          character = %{
+            name: name,
+            class: class,
+            level: level
+          }
+
+          IO.puts("Your character: \"#{character}\"")
+          character
+        end
+      end,
+      defmodule RPG.CharacterSheet do
+        def run() do
+          welcome()
+          name = ask_name()
+          class = ask_class()
+          level = ask_level()
+
+          character = %{
+            name: name,
+            class: class,
+            level: level
+          }
+
+          IO.inspect(character, label: "Your character")
+          character
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "IO.inspect doesn't use the :label option",
+    comments_include: [Constants.rpg_character_sheet_IO_inspect_uses_label()] do
+    defmodule RPG.CharacterSheet do
+      def run() do
+        welcome()
+        name = ask_name()
+        class = ask_class()
+        level = ask_level()
+
+        character = %{
+          name: name,
+          class: class,
+          level: level
+        }
+
+        IO.write("Your character: ")
+        IO.inspect(character)
+      end
+    end
+  end
+end

--- a/test/support/analyzer_verification/feature/block_ends_with.ex
+++ b/test/support/analyzer_verification/feature/block_ends_with.ex
@@ -1,0 +1,116 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.Feature.BlockEndsWith do
+  @moduledoc """
+  This is an exercise analyzer extension module to test the _block_ends_with feature
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+
+  feature "can detect :ok" do
+    type :essential
+    comment "cannot detect :ok"
+
+    form do
+      _block_ends_with do
+        :ok
+      end
+    end
+  end
+
+  feature "can detect two lines" do
+    type :essential
+    comment "cannot detect two lines"
+
+    form do
+      _block_ends_with do
+        name = "Bob"
+        greeting = "hi #{name}"
+      end
+    end
+  end
+
+  feature "can detect pattern matches" do
+    type :essential
+    comment "cannot detect pattern matches"
+
+    form do
+      _block_ends_with do
+        :ok -> "All good"
+        _ -> "Whoops"
+      end
+    end
+  end
+
+  feature "can detect functions" do
+    type :essential
+    comment "cannot detect functions"
+
+    form do
+      _block_ends_with do
+        def foo() do
+          _ignore
+        end
+
+        def bar(_ignore) do
+          _ignore
+        end
+      end
+    end
+  end
+
+  feature "can detect nested blocks" do
+    type :essential
+    comment "cannot detect nested blocks"
+
+    form do
+      defmodule _ignore do
+        _block_ends_with do
+          def foo() do
+            _block_ends_with do
+              name = "Bob"
+              greeting = "hi #{name}"
+            end
+          end
+        end
+      end
+    end
+  end
+
+  feature "cannot match a line and a block on the same level" do
+    type :essential
+    comment "could match a line and a block in a row"
+
+    form do
+      :hello
+
+      _block_ends_with do
+        :goodbye
+      end
+    end
+  end
+
+  feature "cannot match two blocks in a row on the same level" do
+    type :essential
+    comment "could use two in a row"
+
+    form do
+      _block_ends_with do
+        :hello
+      end
+
+      _block_ends_with do
+        :goodbye
+      end
+    end
+  end
+
+  feature "should not use _block_ends_with with a single line wihtout context" do
+    type :essential
+    comment "could not match a line"
+
+    form do
+      _block_ends_with do
+        foo(_ignore)
+      end
+    end
+  end
+end

--- a/test/support/analyzer_verification/feature/block_ends_with.ex
+++ b/test/support/analyzer_verification/feature/block_ends_with.ex
@@ -103,13 +103,26 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.Feature.BlockEndsWith do
     end
   end
 
-  feature "should not use _block_ends_with with a single line wihtout context" do
+  feature "should not use _block_ends_with with a single line without context" do
     type :essential
-    comment "could not match a line"
+    comment "without context: could not match :ok"
 
     form do
       _block_ends_with do
-        foo(_ignore)
+        :ok
+      end
+    end
+  end
+
+  feature "should use _block_ends_with with a single line with a context" do
+    type :essential
+    comment "with context: could not match :ok"
+
+    form do
+      def foo() do
+        _block_ends_with do
+          :ok
+        end
       end
     end
   end


### PR DESCRIPTION
Closes #91. Fixes #91. Does not solve #91.

This PR introduces `_block_ends_with`, a block very similar to `_block_includes`, but the last line must match the last line of the code. This is useful for checking the return value of functions, like in `rpg-character-sheet`.

When trying to match a single line, one must be careful to always put in in a context (module definition, function definition,...) otherwise the match is done line to line and can succeed even when the line isn't the last in the code. I explain that in the docs.

I copy/pasted and modified the tests for `_block_includes`, I'm not sure if that's good practice or if I should have tried to merge the two. Please let me know.