### PR TITLE
[#11] Reorder comments based on importance

### DIFF
--- a/lib/elixir_analyzer/exercise_test.ex
+++ b/lib/elixir_analyzer/exercise_test.ex
@@ -61,6 +61,7 @@ defmodule ElixirAnalyzer.ExerciseTest do
         |> append_test_comments(feature_results)
         |> append_test_comments(assert_call_results)
         |> append_test_comments(common_checks_results)
+        |> Submission.sort_comments()
       end
 
       defp filter_suppressed_results(feature_results) do

--- a/lib/elixir_analyzer/submission.ex
+++ b/lib/elixir_analyzer/submission.ex
@@ -84,7 +84,7 @@ defmodule ElixirAnalyzer.Submission do
     %{submission | comments: comments}
   end
 
-  @comment_importance ~w(essential actionable informative celebratory)a
+  @comment_types ~w{celebratory essential actionable informative}a
 
   @doc """
   Sort submission comments by importance (`:essential` to `:celebratory`)
@@ -92,7 +92,7 @@ defmodule ElixirAnalyzer.Submission do
   def sort_comments(%__MODULE__{comments: comments} = submission) do
     comments =
       Enum.sort_by(comments, fn %{type: type} ->
-        Enum.find_index(@comment_importance, &(&1 == type))
+        Enum.find_index(@comment_types, &(&1 == type))
       end)
 
     %{submission | comments: comments}
@@ -106,7 +106,6 @@ defmodule ElixirAnalyzer.Submission do
     end
   end
 
-  @comment_types ~w{essential actionable informative celebratory}a
   @default_type_frequencies @comment_types |> Enum.map(&{&1, 0}) |> Enum.into(%{})
 
   defp get_summary(%__MODULE__{comments: comments}) do

--- a/lib/elixir_analyzer/submission.ex
+++ b/lib/elixir_analyzer/submission.ex
@@ -84,6 +84,20 @@ defmodule ElixirAnalyzer.Submission do
     %{submission | comments: comments}
   end
 
+  @comment_importance ~w(essential actionable informative celebratory)a
+
+  @doc """
+  Sort submission comments by importance (`:essential` to `:celebratory`)
+  """
+  def sort_comments(%__MODULE__{comments: comments} = submission) do
+    comments =
+      Enum.sort_by(comments, fn %{type: type} ->
+        Enum.find_index(@comment_importance, &(&1 == type))
+      end)
+
+    %{submission | comments: comments}
+  end
+
   defp get_summary(%__MODULE__{halted: true, comments: comments} = submission)
        when comments == [] do
     case submission.halt_reason do

--- a/test/elixir_analyzer/exercise_test/comment_order_test.exs
+++ b/test/elixir_analyzer/exercise_test/comment_order_test.exs
@@ -5,7 +5,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommentOrderTest do
 
   test_exercise_analysis "triggering module",
     # Comments in order of importance
-    comments: ["essential", "actionable", "informative", "celebratory"] do
+    comments: ["celebratory", "essential", "actionable", "informative"] do
     defmodule TriggeringtModule do
       def foo() do
         :celebratory

--- a/test/elixir_analyzer/exercise_test/comment_order_test.exs
+++ b/test/elixir_analyzer/exercise_test/comment_order_test.exs
@@ -1,0 +1,15 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommentOrderTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.Support.AnalyzerVerification.CommentOrder,
+    unsorted_comments: true
+
+  test_exercise_analysis "triggering module",
+    # Comments in order of importance
+    comments: ["essential", "actionable", "informative", "celebratory"] do
+    defmodule TriggeringtModule do
+      def foo() do
+        :celebratory
+      end
+    end
+  end
+end

--- a/test/elixir_analyzer_test.exs
+++ b/test/elixir_analyzer_test.exs
@@ -28,11 +28,10 @@ defmodule ElixirAnalyzerTest do
       path = "./test_data/two_fer/imperfect_solution/"
       analyzed_exercise = ElixirAnalyzer.analyze_exercise(exercise, path, path, @options)
 
-      expected_output = """
-      {\"comments\":[{\"comment\":\"elixir.solution.use_module_doc\",\"type\":\"informative\"},{\"comment\":\"elixir.solution.raise_fn_clause_error\",\"type\":\"actionable\"},{\"comment\":\"elixir.two-fer.use_of_function_header\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_specification\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.variable_name_snake_case\",\"params\":{\"actual\":\"_nameInPascalCase\",\"expected\":\"_name_in_pascal_case\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_pascal_case\",\"params\":{\"actual\":\"My_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.indentation\",\"type\":\"informative\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}
-      """
+      expected_output =
+        "{\"comments\":[{\"comment\":\"elixir.solution.raise_fn_clause_error\",\"type\":\"actionable\"},{\"comment\":\"elixir.two-fer.use_of_function_header\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_specification\",\"type\":\"actionable\"},{\"comment\":\"elixir.solution.variable_name_snake_case\",\"params\":{\"actual\":\"_nameInPascalCase\",\"expected\":\"_name_in_pascal_case\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_attribute_name_snake_case\",\"params\":{\"actual\":\"someUnusedModuleAttribute\",\"expected\":\"some_unused_module_attribute\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.module_pascal_case\",\"params\":{\"actual\":\"My_empty_module\",\"expected\":\"MyEmptyModule\"},\"type\":\"actionable\"},{\"comment\":\"elixir.solution.use_module_doc\",\"type\":\"informative\"},{\"comment\":\"elixir.solution.indentation\",\"type\":\"informative\"}],\"summary\":\"Check the comments for some code suggestions. 📣\"}"
 
-      assert Submission.to_json(analyzed_exercise) == String.trim(expected_output)
+      assert Submission.to_json(analyzed_exercise) == expected_output
     end
 
     # @tag :pending

--- a/test/support/analyzer_verification/comment_order.ex
+++ b/test/support/analyzer_verification/comment_order.ex
@@ -1,0 +1,45 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.CommentOrder do
+  @moduledoc """
+  This is an exercise analyzer extension module to test the order of comments
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+
+  # features are defined in a non-alphabetical, non-importance order
+
+  feature "find :celebratory" do
+    type :celebratory
+    comment "celebratory"
+
+    form do
+      :celebratory
+    end
+  end
+
+  feature "find :essential" do
+    type :essential
+    comment "essential"
+
+    form do
+      :essential
+    end
+  end
+
+  feature "find :informative" do
+    type :informative
+    comment "informative"
+
+    form do
+      :informative
+    end
+  end
+
+  feature "find :actionable" do
+    type :actionable
+    comment "actionable"
+
+    form do
+      :actionable
+    end
+  end
+end

--- a/test/support/exercise_test_case.ex
+++ b/test/support/exercise_test_case.ex
@@ -16,6 +16,7 @@ defmodule ElixirAnalyzer.ExerciseTestCase do
   using opts do
     quote do
       @exercise_test_module unquote(opts)[:exercise_test_module]
+      @unsorted_comments unquote(opts)[:unsorted_comments]
       require ElixirAnalyzer.ExerciseTestCase
       import ElixirAnalyzer.ExerciseTestCase
       alias ElixirAnalyzer.Constants
@@ -97,19 +98,29 @@ defmodule ElixirAnalyzer.ExerciseTestCase do
             result.comments
             |> Enum.map(fn comment_details -> comment_details.comment end)
 
-          Enum.map(Keyword.keys(unquote(assertions)), fn key ->
-            assert_comments(comments, key, unquote(assertions))
+          Enum.map(Keyword.keys(unquote(assertions)), fn
+            :comments ->
+              assert_comments(comments, :comments, unquote(assertions),
+                unsorted: @unsorted_comments
+              )
+
+            key ->
+              assert_comments(comments, key, unquote(assertions))
           end)
         end
       end
     end)
   end
 
-  def assert_comments(comments, :comments, assertions) do
+  def assert_comments(comments, :comments, assertions, unsorted: unsorted) do
     expected_comments = assertions[:comments]
 
-    if expected_comments do
-      assert Enum.sort(comments) == Enum.sort(expected_comments)
+    cond do
+      expected_comments && unsorted ->
+        assert comments == expected_comments
+
+      expected_comments ->
+        assert Enum.sort(comments) == Enum.sort(expected_comments)
     end
   end
 


### PR DESCRIPTION
Fixes #11.

I picked the following order: essential, actionable, informative, celebratory. 
Maybe we want to bump celebratory above informative to be a bit more positive? I don't think we have many celebratory checks yet, but I'm sure we will as we start mentoring solutions... @neenjaw I'm interested in hearing your opinion.

I added a new feature to `test/support/exercise_test_case.ex` just to be able to test this, I hope that's OK.