### PR TITLE
[#40] Write analysis for practice exercise `list-ops`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -65,6 +65,9 @@ config :elixir_analyzer,
     "accumulate" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.Accumulate
     },
+    "list-ops" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.ListOps
+    },
     "square-root" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.SquareRoot
     },

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -81,6 +81,9 @@ defmodule ElixirAnalyzer.Constants do
     # Accumulate Comments
     accumulate_use_recursion: "elixir.accumulate.use_recursion",
 
+    # List Ops Comments
+    list_ops_do_not_use_list_functions: "elixir.list-ops.do_not_use_list_functions",
+
     # Square Root Comments
     square_root_do_not_use_built_in_sqrt: "elixir.square-root.do_not_use_built_in_sqrt",
 

--- a/lib/elixir_analyzer/test_suite/list_ops.ex
+++ b/lib/elixir_analyzer/test_suite/list_ops.ex
@@ -1,0 +1,67 @@
+defmodule ElixirAnalyzer.TestSuite.ListOps do
+  @moduledoc """
+  This is an exercise analyzer test suite for the practive exercise list-ops 
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+
+  assert_no_call "do not call List module" do
+    type :essential
+    called_fn module: List, name: :_
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not call Enum module" do
+    type :essential
+    called_fn module: Enum, name: :_
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not call Stream module" do
+    type :essential
+    called_fn module: Stream, name: :_
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not use ++" do
+    type :essential
+    called_fn name: :++
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not use --" do
+    type :essential
+    called_fn name: :--
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not use hd" do
+    type :essential
+    called_fn name: :hd
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not use tl" do
+    type :essential
+    called_fn name: :tl
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not use in" do
+    type :essential
+    called_fn name: :in
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not use for" do
+    type :essential
+    called_fn name: :for
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+
+  assert_no_call "do not use Kernel.length" do
+    type :essential
+    called_fn module: Kernel, name: :length
+    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+  end
+end

--- a/test/elixir_analyzer/exercise_test/assert_no_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_no_call_test.exs
@@ -63,19 +63,27 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertNoCallTest do
     comments: [
       "found a call to Enum.map in solution"
     ] do
-    defmodule AssertNoCallVerification do
-      def function() do
-        Enum.map([], fn x -> x + 1 end)
-      end
+    [
+      defmodule AssertNoCallVerification do
+        def function() do
+          Enum.map([], fn x -> x + 1 end)
+        end
 
-      def helper do
-        :helped
-      end
+        def helper do
+          :helped
+        end
 
-      defp private_helper do
-        :privately_helped
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      defmodule AssertNoCallVerification do
+        # corner case: local function named the same as the forbidden called function
+        def map() do
+          Enum.map([], fn x -> x + 1 end)
+        end
       end
-    end
+    ]
   end
 
   test_exercise_analysis "calling a function with the same name doesn't trigger the check",

--- a/test/elixir_analyzer/test_suite/high_score_test.exs
+++ b/test/elixir_analyzer/test_suite/high_score_test.exs
@@ -34,7 +34,7 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
   test_exercise_analysis "requires add_player to have a default argument that's a module attribute",
     comments_include: [Constants.high_score_use_default_argument_with_module_attribute()] do
     [
-      def HighScore do
+      defmodule HighScore do
         def add_player(scores, name) do
           Map.put(scores, name, @any_name)
         end
@@ -43,13 +43,13 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
           Map.put(scores, name, score)
         end
       end,
-      def HighScore do
+      defmodule HighScore do
         def add_player(scores, name, score \\ nil) do
           score = score || @initial_score
           Map.put(scores, name, score)
         end
       end,
-      def HighScore do
+      defmodule HighScore do
         def add_player(scores, name, score \\ 0) do
           Map.put(scores, name, score)
         end
@@ -61,7 +61,7 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
     test_exercise_analysis "only the value must match",
       comments_exclude: [Constants.high_score_use_module_attribute()] do
       [
-        def HighScore do
+        defmodule HighScore do
           @initial_score 0
 
           def add_player(scores, name, score \\ @initial_score) do
@@ -72,7 +72,7 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
             Map.put(scores, name, @initial_score)
           end
         end,
-        def HighScore do
+        defmodule HighScore do
           @initial_score 0
 
           def add_player(scores, name) do
@@ -88,7 +88,7 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
             Map.update(scores, name, @initial_score, fn _ -> @initial_score end)
           end
         end,
-        def HighScore do
+        defmodule HighScore do
           @init 0
 
           def add_player(scores, name, score \\ @init) do
@@ -128,7 +128,7 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
             Map.put(scores, name, 0)
           end
         end,
-        def HighScore do
+        defmodule HighScore do
           @initial_score 3
 
           def new(), do: %{}
@@ -141,7 +141,7 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
             Map.put(scores, name, @initial_score)
           end
         end,
-        def HighScore do
+        defmodule HighScore do
           @initial_score 0
 
           def new(), do: %{}
@@ -154,7 +154,7 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
             Map.put(scores, name, 0)
           end
         end,
-        def HighScore do
+        defmodule HighScore do
           @initial_score 0
 
           def new(), do: %{}

--- a/test/elixir_analyzer/test_suite/list_ops_test.exs
+++ b/test/elixir_analyzer/test_suite/list_ops_test.exs
@@ -1,0 +1,121 @@
+defmodule ElixirAnalyzer.ExerciseTest.ListOpsTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.TestSuite.ListOps
+
+  test_exercise_analysis "example solution",
+    comments: [] do
+    defmodule ListOps do
+      @spec length(list) :: non_neg_integer
+      def length(l), do: do_length(l, 0)
+
+      defp do_length([], acc), do: acc
+      defp do_length([_ | t], acc), do: do_length(t, acc + 1)
+
+      @spec reverse(list) :: list
+      def reverse(l), do: do_reverse(l, [])
+
+      defp do_reverse([], acc), do: acc
+      defp do_reverse([h | t], acc), do: do_reverse(t, [h | acc])
+
+      @spec map(list, (any -> any)) :: list
+      def map(l, f), do: do_map(l, f, []) |> reverse()
+
+      defp do_map([], _, acc), do: acc
+      defp do_map([h | t], f, acc), do: do_map(t, f, [f.(h) | acc])
+
+      @spec filter(list, (any -> as_boolean(term))) :: list
+      def filter(l, f), do: do_filter(l, f, []) |> reverse()
+
+      defp do_filter([], _, acc), do: acc
+
+      defp do_filter([h | t], f, acc) do
+        if f.(h) do
+          do_filter(t, f, [h | acc])
+        else
+          do_filter(t, f, acc)
+        end
+      end
+
+      @type acc :: any
+      @spec foldl(list, acc, (any, acc -> acc)) :: acc
+      def foldl([], acc, _), do: acc
+      def foldl([h | t], acc, f), do: foldl(t, f.(h, acc), f)
+
+      @spec foldr(list, acc, (any, acc -> acc)) :: acc
+      def foldr([], acc, _), do: acc
+      def foldr([h | t], acc, f), do: f.(h, foldr(t, acc, f))
+
+      @spec append(list, list) :: list
+      def append(a, b), do: do_append(reverse(a), b)
+
+      defp do_append([], b), do: b
+      defp do_append([h | t], b), do: do_append(t, [h | b])
+
+      @spec concat([[any]]) :: [any]
+      def concat(ll), do: reverse(ll) |> foldl([], &append(&1, &2))
+    end
+  end
+
+  test_exercise_analysis "illegal implementations",
+    comments: [Constants.list_ops_do_not_use_list_functions()] do
+    [
+      defmodule ListOps do
+        def filter(p, l), do: Enum.filter(p, l)
+      end,
+      defmodule ListOps do
+        import Enum
+        def filter(p, l), do: filter(p, l)
+      end,
+      defmodule ListOps do
+        import Enum, only: [reduce: 3]
+        def foldr(l, a, f), do: reduce(l, a, f)
+      end,
+      defmodule ListOps do
+        alias Enum, as: E
+        def filter(p, l), do: E.filter(p, l)
+      end,
+      defmodule ListOps do
+        import List
+        def foldr(l, a, f), do: List.foldr(l, a, f)
+      end,
+      defmodule ListOps do
+        import Stream
+        def filter(l, a, f), do: Stream.filter(l, a, f) |> Enum.to_list()
+      end,
+      defmodule ListOps do
+        def append(l1, l2), do: l1 ++ l2
+      end,
+      defmodule ListOps do
+        def map(l) do
+          try do
+            hd(l)
+          rescue
+            _ -> []
+          else
+            h -> [h | map(tl(l))]
+          end
+        end
+      end,
+      defmodule ListOps do
+        def filter(p, l) do
+          for x <- l,
+              p(x) do
+            x
+          end
+        end
+      end,
+      defmodule ListOps do
+        def filter(p, [h | _] = l) do
+          if p.(h) do
+            [h | filter(l -- [h])]
+          else
+            filter(l -- [h])
+          end
+        end
+      end,
+      defmodule ListOps do
+        def length(l), do: Kernel.length(l)
+      end
+    ]
+  end
+end


### PR DESCRIPTION
Fixes #40.

I could not find a reasonable way of using `in` in an implementation so I left that test out.
I added `for` to the list of forbidden functions.

On the way, I had to patch the `assert_call` compiler because it would not flag a function names used in a function definition of the same name so `def length(l), do: Kernel.length(l)` would not get flagged. This lead me to find bugs in some `high-score` tests.