### PR TITLE
[#90] Write analysis for concept exercise `newsletter`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -54,6 +54,9 @@ config :elixir_analyzer,
     "need-for-speed" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.NeedForSpeed
     },
+    "newsletter" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.Newsletter
+    },
     "pacman-rules" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.PacmanRules
     },

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -75,8 +75,6 @@ defmodule ElixirAnalyzer.Constants do
     newsletter_open_log_uses_option_write: "elixir.newsletter.open_log_uses_option_write",
     newsletter_send_newsletter_reuses_functions:
       "elixir.newsletter.send_newsletter_reuses_functions",
-    newsletter_send_newsletter_does_not_call_write:
-      "elixir.newsletter.send_newsletter_does_not_call_write",
 
     # Pacman Rules Comments
     pacman_rules_use_strictly_boolean_operators:

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -66,6 +66,16 @@ defmodule ElixirAnalyzer.Constants do
     need_for_speed_import_ANSI_with_except: "elixir.need-for-speed.import_ANSI_with_except",
     need_for_speed_do_not_modify_code: "elixir.need-for-speed.do_not_modify_code",
 
+    # Newsletter Comments
+    newsletter_close_log_returns_implicitly: "elixir.newsletter.close_log_returns_implicitly",
+    newsletter_log_sent_email_returns_implicitly:
+      "elixir.newsletter.log_sent_email_returns_implicitly",
+    newsletter_send_newsletter_returns_implicitly:
+      "elixir.newsletter.send_newsletter_returns_implicitly",
+    newsletter_open_log_uses_option_write: "elixir.newsletter.open_log_uses_option_write",
+    newsletter_send_newsletter_does_not_call_write:
+      "elixir.newsletter.send_newsletter_does_not_call_write",
+
     # Pacman Rules Comments
     pacman_rules_use_strictly_boolean_operators:
       "elixir.pacman-rules.use_strictly_boolean_operators",
@@ -89,6 +99,7 @@ defmodule ElixirAnalyzer.Constants do
     rpn_calculator_output_write_in_try: "elixir.rpn-calculator-output.write_in_try",
     rpn_calculator_output_output_in_else: "elixir.rpn-calculator-output.output_in_else",
     rpn_calculator_output_close_in_after: "elixir.rpn-calculator-output.close_in_after",
+
     # Take A Number Comments
     take_a_number_do_not_use_abstractions: "elixir.take-a-number.do_not_use_abstractions",
 

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -73,6 +73,8 @@ defmodule ElixirAnalyzer.Constants do
     newsletter_send_newsletter_returns_implicitly:
       "elixir.newsletter.send_newsletter_returns_implicitly",
     newsletter_open_log_uses_option_write: "elixir.newsletter.open_log_uses_option_write",
+    newsletter_send_newsletter_reuses_functions:
+      "elixir.newsletter.send_newsletter_reuses_functions",
     newsletter_send_newsletter_does_not_call_write:
       "elixir.newsletter.send_newsletter_does_not_call_write",
 

--- a/lib/elixir_analyzer/test_suite/newsletter.ex
+++ b/lib/elixir_analyzer/test_suite/newsletter.ex
@@ -47,8 +47,17 @@ defmodule ElixirAnalyzer.TestSuite.Newsletter do
   end
 
   feature "open_log used the option :write" do
+    find :any
     type :essential
     comment Constants.newsletter_open_log_uses_option_write()
+
+    form do
+      def open_log(_ignore) do
+        _block_includes do
+          File.open(_ignore, [:write])
+        end
+      end
+    end
 
     form do
       def open_log(_ignore) do

--- a/lib/elixir_analyzer/test_suite/newsletter.ex
+++ b/lib/elixir_analyzer/test_suite/newsletter.ex
@@ -59,6 +59,34 @@ defmodule ElixirAnalyzer.TestSuite.Newsletter do
     end
   end
 
+  assert_call "send_newsletter/3 calls open_log/1" do
+    type :actionable
+    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_reuses_functions()
+    called_fn name: :open_log
+    calling_fn module: Newsletter, name: :send_newsletter
+  end
+
+  assert_call "send_newsletter/3 calls close_log/1" do
+    type :actionable
+    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_reuses_functions()
+    called_fn name: :close_log
+    calling_fn module: Newsletter, name: :send_newsletter
+  end
+
+  assert_call "send_newsletter/3 calls read_emails/1" do
+    type :actionable
+    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_reuses_functions()
+    called_fn name: :read_emails
+    calling_fn module: Newsletter, name: :send_newsletter
+  end
+
+  assert_call "send_newsletter/3 calls log_sent_email/2" do
+    type :actionable
+    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_reuses_functions()
+    called_fn name: :log_sent_email
+    calling_fn module: Newsletter, name: :send_newsletter
+  end
+
   assert_no_call "send_newsletter/3 doesn't use File.write" do
     type :essential
     comment ElixirAnalyzer.Constants.newsletter_send_newsletter_does_not_call_write()

--- a/lib/elixir_analyzer/test_suite/newsletter.ex
+++ b/lib/elixir_analyzer/test_suite/newsletter.ex
@@ -86,18 +86,4 @@ defmodule ElixirAnalyzer.TestSuite.Newsletter do
     called_fn name: :log_sent_email
     calling_fn module: Newsletter, name: :send_newsletter
   end
-
-  assert_no_call "send_newsletter/3 doesn't use File.write" do
-    type :essential
-    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_does_not_call_write()
-    called_fn module: File, name: :write
-    calling_fn module: Newsletter, name: :send_newsletter
-  end
-
-  assert_no_call "send_newsletter/3 doesn't use File.write!" do
-    type :essential
-    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_does_not_call_write()
-    called_fn module: File, name: :write!
-    calling_fn module: Newsletter, name: :send_newsletter
-  end
 end

--- a/lib/elixir_analyzer/test_suite/newsletter.ex
+++ b/lib/elixir_analyzer/test_suite/newsletter.ex
@@ -1,0 +1,75 @@
+defmodule ElixirAnalyzer.TestSuite.Newsletter do
+  @moduledoc """
+  This is an exercise analyzer extension module for the concept exercise Newsletter 
+  """
+
+  alias ElixirAnalyzer.Constants
+
+  use ElixirAnalyzer.ExerciseTest
+
+  feature "close_log ends with File.close" do
+    type :actionable
+    comment Constants.newsletter_close_log_returns_implicitly()
+
+    form do
+      def close_log(_ignore) do
+        _block_ends_with do
+          File.close(_ignore)
+        end
+      end
+    end
+  end
+
+  feature "log_sent_email ends with IO.puts" do
+    type :actionable
+    comment Constants.newsletter_log_sent_email_returns_implicitly()
+
+    form do
+      def log_sent_email(_ignore, _ignore) do
+        _block_ends_with do
+          IO.puts(_ignore, _ignore)
+        end
+      end
+    end
+  end
+
+  feature "send_newsletter ends with close_log" do
+    type :actionable
+    comment Constants.newsletter_send_newsletter_returns_implicitly()
+
+    form do
+      def send_newsletter(_ignore, _ignore, _ignore) do
+        _block_ends_with do
+          close_log(_ignore)
+        end
+      end
+    end
+  end
+
+  feature "open_log used the option :write" do
+    type :essential
+    comment Constants.newsletter_open_log_uses_option_write()
+
+    form do
+      def open_log(_ignore) do
+        _block_includes do
+          File.open!(_ignore, [:write])
+        end
+      end
+    end
+  end
+
+  assert_no_call "send_newsletter/3 doesn't use File.write" do
+    type :essential
+    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_does_not_call_write()
+    called_fn module: File, name: :write
+    calling_fn module: Newsletter, name: :send_newsletter
+  end
+
+  assert_no_call "send_newsletter/3 doesn't use File.write!" do
+    type :essential
+    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_does_not_call_write()
+    called_fn module: File, name: :write!
+    calling_fn module: Newsletter, name: :send_newsletter
+  end
+end

--- a/test/elixir_analyzer/test_suite/newsletter_test.exs
+++ b/test/elixir_analyzer/test_suite/newsletter_test.exs
@@ -218,28 +218,4 @@ defmodule ElixirAnalyzer.ExerciseTest.NewsletterTest do
       end
     end
   end
-
-  test_exercise_analysis "send_newsletter uses File.write",
-    comments_include: [Constants.newsletter_send_newsletter_does_not_call_write()] do
-    [
-      defmodule Newsletter do
-        def send_newsletter(emails_path, log_path, send_fun) do
-          read_emails(emails_path)
-          |> Enum.each(fn email ->
-            if send_fun.(email) == :ok,
-              do: File.write(log_path, email <> "\n", [:append])
-          end)
-        end
-      end,
-      defmodule Newsletter do
-        def send_newsletter(emails_path, log_path, send_fun) do
-          read_emails(emails_path)
-          |> Enum.each(fn email ->
-            if send_fun.(email) == :ok,
-              do: File.write!(log_path, email <> "\n", [:append])
-          end)
-        end
-      end
-    ]
-  end
 end

--- a/test/elixir_analyzer/test_suite/newsletter_test.exs
+++ b/test/elixir_analyzer/test_suite/newsletter_test.exs
@@ -117,26 +117,48 @@ defmodule ElixirAnalyzer.ExerciseTest.NewsletterTest do
 
   test_exercise_analysis "open_log uses :append",
     comments_include: [Constants.newsletter_open_log_uses_option_write()] do
-    defmodule Newsletter do
-      def open_log(path) do
-        File.open!(path, [:append])
+    [
+      defmodule Newsletter do
+        def open_log(path) do
+          File.open(path, [:append])
+        end
+
+        def send_newsletter(emails_path, log_path, send_fun) do
+          emails = read_emails(emails_path)
+
+          Enum.each(emails, fn email ->
+            log_pid = open_log(log_path)
+
+            case send_fun.(email) do
+              :ok -> log_sent_email(log_pid, email)
+              _ -> nil
+            end
+
+            close_log(log_pid)
+          end)
+        end
+      end,
+      defmodule Newsletter do
+        def open_log(path) do
+          File.open!(path, [:append])
+        end
+
+        def send_newsletter(emails_path, log_path, send_fun) do
+          emails = read_emails(emails_path)
+
+          Enum.each(emails, fn email ->
+            log_pid = open_log(log_path)
+
+            case send_fun.(email) do
+              :ok -> log_sent_email(log_pid, email)
+              _ -> nil
+            end
+
+            close_log(log_pid)
+          end)
+        end
       end
-
-      def send_newsletter(emails_path, log_path, send_fun) do
-        emails = read_emails(emails_path)
-
-        Enum.each(emails, fn email ->
-          log_pid = open_log(log_path)
-
-          case send_fun.(email) do
-            :ok -> log_sent_email(log_pid, email)
-            _ -> nil
-          end
-
-          close_log(log_pid)
-        end)
-      end
-    end
+    ]
   end
 
   describe "send_newsletter doesn't reuse other functions" do

--- a/test/elixir_analyzer/test_suite/newsletter_test.exs
+++ b/test/elixir_analyzer/test_suite/newsletter_test.exs
@@ -139,6 +139,86 @@ defmodule ElixirAnalyzer.ExerciseTest.NewsletterTest do
     end
   end
 
+  describe "send_newsletter doesn't reuse other functions" do
+    test_exercise_analysis "send_newsletter doesn't use open_log",
+      comments_include: [Constants.newsletter_send_newsletter_reuses_functions()] do
+      defmodule Newsletter do
+        def send_newsletter(emails_path, log_path, send_fun) do
+          log_pid = File.open!(path, [:write])
+          emails = read_emails(emails_path)
+
+          Enum.each(emails, fn email ->
+            case send_fun.(email) do
+              :ok -> log_sent_email(log_pid, email)
+              _ -> nil
+            end
+          end)
+
+          close_log(log_pid)
+        end
+      end
+    end
+
+    test_exercise_analysis "send_newsletter doesn't use close_log",
+      comments_include: [Constants.newsletter_send_newsletter_reuses_functions()] do
+      defmodule Newsletter do
+        def send_newsletter(emails_path, log_path, send_fun) do
+          log_pid = open_log(log_path)
+          emails = read_emails(emails_path)
+
+          Enum.each(emails, fn email ->
+            case send_fun.(email) do
+              :ok -> log_sent_email(log_pid, email)
+              _ -> nil
+            end
+          end)
+
+          File.close(log_pid)
+        end
+      end
+    end
+
+    test_exercise_analysis "send_newsletter doesn't use read_emails",
+      comments_include: [Constants.newsletter_send_newsletter_reuses_functions()] do
+      defmodule Newsletter do
+        def send_newsletter(emails_path, log_path, send_fun) do
+          log_pid = open_log(log_path)
+
+          emails_path
+          |> File.read!()
+          |> String.split()
+          |> Enum.each(fn email ->
+            case send_fun.(email) do
+              :ok -> log_sent_email(log_pid, email)
+              _ -> nil
+            end
+          end)
+
+          close_log(log_pid)
+        end
+      end
+    end
+
+    test_exercise_analysis "send_newsletter doesn't use log_sent_email",
+      comments_include: [Constants.newsletter_send_newsletter_reuses_functions()] do
+      defmodule Newsletter do
+        def send_newsletter(emails_path, log_path, send_fun) do
+          log_pid = open_log(log_path)
+          emails = read_emails(emails_path)
+
+          Enum.each(emails, fn email ->
+            case send_fun.(email) do
+              :ok -> IO.puts(log_pid, email)
+              _ -> nil
+            end
+          end)
+
+          close_log(log_pid)
+        end
+      end
+    end
+  end
+
   test_exercise_analysis "send_newsletter uses File.write",
     comments_include: [Constants.newsletter_send_newsletter_does_not_call_write()] do
     [

--- a/test/elixir_analyzer/test_suite/newsletter_test.exs
+++ b/test/elixir_analyzer/test_suite/newsletter_test.exs
@@ -1,0 +1,165 @@
+defmodule ElixirAnalyzer.ExerciseTest.NewsletterTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.TestSuite.Newsletter
+
+  test_exercise_analysis "example solution",
+    comments: [] do
+    defmodule Newsletter do
+      def read_emails(path) do
+        path
+        |> File.read!()
+        |> String.split()
+      end
+
+      def open_log(path) do
+        File.open!(path, [:write])
+      end
+
+      def log_sent_email(pid, email) do
+        IO.puts(pid, email)
+      end
+
+      def close_log(pid) do
+        File.close(pid)
+      end
+
+      def send_newsletter(emails_path, log_path, send_fun) do
+        log_pid = open_log(log_path)
+        emails = read_emails(emails_path)
+
+        Enum.each(emails, fn email ->
+          case send_fun.(email) do
+            :ok -> log_sent_email(log_pid, email)
+            _ -> nil
+          end
+        end)
+
+        close_log(log_pid)
+      end
+    end
+  end
+
+  describe "detects non-implicit returns" do
+    test_exercise_analysis "explicit return in close_log",
+      comments_include: [Constants.newsletter_close_log_returns_implicitly()] do
+      [
+        defmodule Newsletter do
+          def close_log(pid) do
+            File.close(pid)
+            :ok
+          end
+        end,
+        defmodule Newsletter do
+          def close_log(pid) do
+            x = File.close(pid)
+            x
+          end
+        end
+      ]
+    end
+
+    test_exercise_analysis "explicit return in log_sent_email",
+      comments_include: [Constants.newsletter_log_sent_email_returns_implicitly()] do
+      [
+        defmodule Newsletter do
+          def log_sent_email(pid, email) do
+            IO.puts(pid, email)
+            :ok
+          end
+        end,
+        defmodule Newsletter do
+          def log_sent_email(pid, email) do
+            x = IO.puts(pid, email)
+            x
+          end
+        end
+      ]
+    end
+
+    test_exercise_analysis "explicit return in send_newsletter",
+      comments_include: [Constants.newsletter_send_newsletter_returns_implicitly()] do
+      [
+        defmodule Newsletter do
+          def send_newsletter(emails_path, log_path, send_fun) do
+            log_pid = open_log(log_path)
+            emails = read_emails(emails_path)
+
+            Enum.each(emails, fn email ->
+              case send_fun.(email) do
+                :ok -> log_sent_email(log_pid, email)
+                _ -> nil
+              end
+            end)
+
+            close_log(log_pid)
+            :ok
+          end
+        end,
+        defmodule Newsletter do
+          def send_newsletter(emails_path, log_path, send_fun) do
+            log_pid = open_log(log_path)
+            emails = read_emails(emails_path)
+
+            Enum.each(emails, fn email ->
+              case send_fun.(email) do
+                :ok -> log_sent_email(log_pid, email)
+                _ -> nil
+              end
+            end)
+
+            x = close_log(log_pid)
+            x
+          end
+        end
+      ]
+    end
+  end
+
+  test_exercise_analysis "open_log uses :append",
+    comments_include: [Constants.newsletter_open_log_uses_option_write()] do
+    defmodule Newsletter do
+      def open_log(path) do
+        File.open!(path, [:append])
+      end
+
+      def send_newsletter(emails_path, log_path, send_fun) do
+        emails = read_emails(emails_path)
+
+        Enum.each(emails, fn email ->
+          log_pid = open_log(log_path)
+
+          case send_fun.(email) do
+            :ok -> log_sent_email(log_pid, email)
+            _ -> nil
+          end
+
+          close_log(log_pid)
+        end)
+      end
+    end
+  end
+
+  test_exercise_analysis "send_newsletter uses File.write",
+    comments_include: [Constants.newsletter_send_newsletter_does_not_call_write()] do
+    [
+      defmodule Newsletter do
+        def send_newsletter(emails_path, log_path, send_fun) do
+          read_emails(emails_path)
+          |> Enum.each(fn email ->
+            if send_fun.(email) == :ok,
+              do: File.write(log_path, email <> "\n", [:append])
+          end)
+        end
+      end,
+      defmodule Newsletter do
+        def send_newsletter(emails_path, log_path, send_fun) do
+          read_emails(emails_path)
+          |> Enum.each(fn email ->
+            if send_fun.(email) == :ok,
+              do: File.write!(log_path, email <> "\n", [:append])
+          end)
+        end
+      end
+    ]
+  end
+end


### PR DESCRIPTION
Closes #90.

Disclaimer: @angelikatyborska I know this is a terribly busy time for you, this can totally wait :)

This PR is not finished, I have some questions first. The instructions in `design.md` say:
- ensure that `send_newsletter/3` calls `open_log/1` and `close_log/1` exactly once each, and doesn't use `File.write`.

I tried to make examples of code with using `open_log` more than once, but it felt silly (why write that command twice in a row?) unless they used `open_log` inside of a loop for each email. However to pass the tests in tat situation, I had to change 
```elixir
def open_log(path) do
  File.open!(path, [:write])
end
```
to
```elixir
def open_log(path) do
  File.open!(path, [:append])
end
```
So I thought that I would replace that test by "open_log uses the :write option" might make more sense, which is what is committed now.  Then, thinking more about  it, I realized that situations could very nicely be avoided by adding one more test in the test suite:

```elixir
    @tag task_id: 5
    test "sending the same newsletter twice resets the log" do
      send_fun = fn _ -> :ok end 
      Newsletter.send_newsletter(Path.join(["assets", "emails.txt"]), @temp_file_path, send_fun)
      Newsletter.send_newsletter(Path.join(["assets", "emails.txt"]), @temp_file_path, send_fun)

      assert File.read!(@temp_file_path) ==
               """ 
               alice@example.com
               bob@example.com
               charlie@example.com
               dave@example.com
               """
    end 
```
That being said, maybe a logger _should_ append and not reset.

So I am full of doubts here. 

1. What use case did you want to prevent by using writing "ensure that `send_newsletter/3` calls `open_log/1` and `close_log/1` exactly once each"?
2. Should I make sure they use `:write` (the instructions are pretty clear that they should)?
3. Should I check for both 1 and 2?
3. Should I add "sending the same newsletter twice resets the log" to the test suite? In that case, maybe 2 becomes useless.