### PR TITLE
[#130] Add a common check for IO.inspect

### DIFF
--- a/lib/elixir_analyzer/comment.ex
+++ b/lib/elixir_analyzer/comment.ex
@@ -4,7 +4,7 @@ defmodule ElixirAnalyzer.Comment do
   (see https://github.com/exercism/docs/blob/main/building/tooling/analyzers/interface.md#comments)
   """
 
-  defstruct status: :test, name: nil, comment: nil, type: nil, suppress_if: nil, params: nil
+  defstruct status: :test, name: nil, comment: nil, type: nil, suppress_if: false, params: nil
 
   @type t :: %__MODULE__{
           name: String.t(),

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -23,6 +23,7 @@ defmodule ElixirAnalyzer.Constants do
     solution_function_name_snake_case: "elixir.solution.function_name_snake_case",
     solution_variable_name_snake_case: "elixir.solution.variable_name_snake_case",
     solution_indentation: "elixir.solution.indentation",
+    solution_debug_functions: "elixir.solution.debug_functions",
 
     # Concept exercises
 

--- a/lib/elixir_analyzer/exercise_test.ex
+++ b/lib/elixir_analyzer/exercise_test.ex
@@ -10,10 +10,12 @@ defmodule ElixirAnalyzer.ExerciseTest do
   alias ElixirAnalyzer.Comment
 
   @doc false
-  defmacro __using__(_opts) do
+  defmacro __using__(opts) do
     quote do
       use ElixirAnalyzer.ExerciseTest.Feature
       use ElixirAnalyzer.ExerciseTest.AssertCall
+      @suppress_tests unquote(opts)[:suppress_tests]
+      @suppress_common_tests unquote(opts)[:suppress_common_tests]
 
       import unquote(__MODULE__)
       @before_compile unquote(__MODULE__)
@@ -29,6 +31,8 @@ defmodule ElixirAnalyzer.ExerciseTest do
     # credo:disable-for-previous-line Credo.Check.Refactor.CyclomaticComplexity
     feature_test_data = Module.get_attribute(env.module, :feature_tests)
     assert_call_data = Module.get_attribute(env.module, :assert_call_tests)
+    suppress_tests = Module.get_attribute(env.module, :suppress_tests, [])
+    suppress_common_tests = Module.get_attribute(env.module, :suppress_common_tests)
 
     # ast placeholder for the submission code ast
     code_ast = quote do: code_ast
@@ -53,25 +57,30 @@ defmodule ElixirAnalyzer.ExerciseTest do
 
       defp do_analyze(%Submission{} = submission, code_ast, code_as_string)
            when is_binary(code_as_string) do
-        feature_results = unquote(feature_tests) |> filter_suppressed_results()
-        assert_call_results = unquote(assert_call_tests) |> filter_suppressed_results()
-        common_checks_results = CommonChecks.run(code_ast, code_as_string)
+        results =
+          Enum.concat([
+            unquote(feature_tests),
+            unquote(assert_call_tests),
+            if unquote(suppress_common_tests) do
+              []
+            else
+              CommonChecks.run(code_ast, code_as_string)
+            end
+          ])
+          |> filter_suppressed_results()
 
         submission
-        |> append_test_comments(feature_results)
-        |> append_test_comments(assert_call_results)
-        |> append_test_comments(common_checks_results)
+        |> append_test_comments(results)
         |> Submission.sort_comments()
       end
 
       defp filter_suppressed_results(feature_results) do
-        feature_results
-        |> Enum.reject(fn
+        Enum.reject(feature_results, fn
           {_test_result, %{suppress_if: condition}} when condition !== false ->
             any_result_matches_suppress_condition?(feature_results, condition)
 
-          _result ->
-            false
+          {_test_result, %{comment: comment}} ->
+            comment in unquote(suppress_tests)
         end)
       end
 

--- a/lib/elixir_analyzer/exercise_test.ex
+++ b/lib/elixir_analyzer/exercise_test.ex
@@ -14,8 +14,8 @@ defmodule ElixirAnalyzer.ExerciseTest do
     quote do
       use ElixirAnalyzer.ExerciseTest.Feature
       use ElixirAnalyzer.ExerciseTest.AssertCall
+      use ElixirAnalyzer.ExerciseTest.CommonChecks
       @suppress_tests unquote(opts)[:suppress_tests]
-      @suppress_common_tests unquote(opts)[:suppress_common_tests]
 
       import unquote(__MODULE__)
       @before_compile unquote(__MODULE__)
@@ -32,7 +32,6 @@ defmodule ElixirAnalyzer.ExerciseTest do
     feature_test_data = Module.get_attribute(env.module, :feature_tests)
     assert_call_data = Module.get_attribute(env.module, :assert_call_tests)
     suppress_tests = Module.get_attribute(env.module, :suppress_tests, [])
-    suppress_common_tests = Module.get_attribute(env.module, :suppress_common_tests)
 
     # ast placeholder for the submission code ast
     code_ast = quote do: code_ast
@@ -61,11 +60,7 @@ defmodule ElixirAnalyzer.ExerciseTest do
           Enum.concat([
             unquote(feature_tests),
             unquote(assert_call_tests),
-            if unquote(suppress_common_tests) do
-              []
-            else
-              CommonChecks.run(code_ast, code_as_string)
-            end
+            CommonChecks.run(code_ast, code_as_string)
           ])
           |> filter_suppressed_results()
 

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -7,9 +7,15 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNames
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.ModuleAttributeNames
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase
-  alias ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.Indentation
   alias ElixirAnalyzer.Comment
+
+  # CommonChecks that use feature or assert_call should be called here
+  defmacro __using__(_opts) do
+    quote do
+      use ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions
+    end
+  end
 
   @spec run(Macro.t(), String.t()) :: [{:pass | :fail | :skip, %Comment{}}]
   def run(code_ast, code_as_string) when is_binary(code_as_string) do
@@ -18,7 +24,6 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
       VariableNames.run(code_ast),
       ModuleAttributeNames.run(code_ast),
       ModulePascalCase.run(code_ast),
-      DebugFunctions.run(code_as_string),
       Indentation.run(code_ast, code_as_string)
     ]
     |> List.flatten()

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -7,6 +7,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNames
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.ModuleAttributeNames
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase
+  alias ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions
   alias ElixirAnalyzer.ExerciseTest.CommonChecks.Indentation
   alias ElixirAnalyzer.Comment
 
@@ -17,6 +18,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
       VariableNames.run(code_ast),
       ModuleAttributeNames.run(code_ast),
       ModulePascalCase.run(code_ast),
+      DebugFunctions.run(code_as_string),
       Indentation.run(code_ast, code_as_string)
     ]
     |> List.flatten()

--- a/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
@@ -10,7 +10,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions do
   use ElixirAnalyzer.ExerciseTest, suppress_common_tests: true
 
   assert_no_call "solution doesn't use IO.inspect" do
-    type :actionable
+    type :informational
     comment ElixirAnalyzer.Constants.solution_debug_functions()
     called_fn module: IO, name: :inspect
   end

--- a/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
@@ -1,0 +1,32 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions do
+  @moduledoc """
+  This is an exercise analyzer extension module used for common tests lookin for debugging functions
+  """
+
+  alias ElixirAnalyzer.Comment
+  alias ElixirAnalyzer.Submission
+
+  # Suppressing common tests prevents this module to recursively call common tests
+  use ElixirAnalyzer.ExerciseTest, suppress_common_tests: true
+
+  assert_no_call "solution doesn't use IO.inspect" do
+    type :actionable
+    comment ElixirAnalyzer.Constants.solution_debug_functions()
+    called_fn module: IO, name: :inspect
+  end
+
+  @spec run(String.t()) :: [{:fail, %Comment{}}]
+  def run(code_as_string) do
+    %Submission{comments: comments} =
+      %Submission{code_file: "", code_path: "", path: "", analysis_module: __MODULE__}
+      |> __MODULE__.analyze(code_as_string)
+
+    case comments do
+      [%{comment: comment, type: type} | _] ->
+        [{:fail, %Comment{comment: comment, type: type, name: comment}}]
+
+      _ ->
+        []
+    end
+  end
+end

--- a/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
@@ -3,30 +3,13 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions do
   This is an exercise analyzer extension module used for common tests lookin for debugging functions
   """
 
-  alias ElixirAnalyzer.Comment
-  alias ElixirAnalyzer.Submission
-
-  # Suppressing common tests prevents this module to recursively call common tests
-  use ElixirAnalyzer.ExerciseTest, suppress_common_tests: true
-
-  assert_no_call "solution doesn't use IO.inspect" do
-    type :informational
-    comment ElixirAnalyzer.Constants.solution_debug_functions()
-    called_fn module: IO, name: :inspect
-  end
-
-  @spec run(String.t()) :: [{:fail, %Comment{}}]
-  def run(code_as_string) do
-    %Submission{comments: comments} =
-      %Submission{code_file: "", code_path: "", path: "", analysis_module: __MODULE__}
-      |> __MODULE__.analyze(code_as_string)
-
-    case comments do
-      [%{comment: comment, type: type} | _] ->
-        [{:fail, %Comment{comment: comment, type: type, name: comment}}]
-
-      _ ->
-        []
+  defmacro __using__(_opts) do
+    quote do
+      assert_no_call unquote(ElixirAnalyzer.Constants.solution_debug_functions()) do
+        type :informational
+        comment ElixirAnalyzer.Constants.solution_debug_functions()
+        called_fn module: IO, name: :inspect
+      end
     end
   end
 end

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_names.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_names.ex
@@ -26,6 +26,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionNames do
         {:fail,
          %Comment{
            type: :actionable,
+           name: Constants.solution_function_name_snake_case(),
            comment: Constants.solution_function_name_snake_case(),
            params: %{
              expected: correct_name,

--- a/lib/elixir_analyzer/exercise_test/common_checks/indentation.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/indentation.ex
@@ -13,6 +13,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.Indentation do
         {:fail,
          %Comment{
            type: :informative,
+           name: Constants.solution_indentation(),
            comment: Constants.solution_indentation()
          }}
       ]

--- a/lib/elixir_analyzer/exercise_test/common_checks/module_attribute_names.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/module_attribute_names.ex
@@ -24,6 +24,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModuleAttributeNames do
         {:fail,
          %Comment{
            type: :actionable,
+           name: Constants.solution_module_attribute_name_snake_case(),
            comment: Constants.solution_module_attribute_name_snake_case(),
            params: %{
              expected: correct_name,

--- a/lib/elixir_analyzer/exercise_test/common_checks/module_pascal_case.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/module_pascal_case.ex
@@ -24,6 +24,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase do
         {:fail,
          %Comment{
            type: :actionable,
+           name: Constants.solution_module_pascal_case(),
            comment: Constants.solution_module_pascal_case(),
            params: %{
              expected: correct_name,

--- a/lib/elixir_analyzer/exercise_test/common_checks/variable_names.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/variable_names.ex
@@ -27,6 +27,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNames do
         {:fail,
          %Comment{
            type: :actionable,
+           name: Constants.solution_variable_name_snake_case(),
            comment: Constants.solution_variable_name_snake_case(),
            params: %{
              expected: correct_name,

--- a/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
+++ b/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
@@ -3,8 +3,10 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheet do
   This is an exercise analyzer extension module for the concept exercise rpg-character-sheet
   """
 
-  use ElixirAnalyzer.ExerciseTest
   alias ElixirAnalyzer.Constants
+
+  use ElixirAnalyzer.ExerciseTest,
+    suppress_tests: [Constants.solution_debug_functions()]
 
   feature "welcome ends with IO.puts" do
     type :actionable

--- a/test/elixir_analyzer/exercise_test/common_checks/function_names_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_names_test.exs
@@ -61,6 +61,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionNamesTest do
               %Comment{
                 type: :actionable,
                 comment: Constants.solution_function_name_snake_case(),
+                name: Constants.solution_function_name_snake_case(),
                 params: %{
                   expected: "first_name",
                   actual: "firstName"
@@ -76,6 +77,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionNamesTest do
          %Comment{
            type: :actionable,
            comment: Constants.solution_function_name_snake_case(),
+           name: Constants.solution_function_name_snake_case(),
            params: %{
              expected: expected,
              actual: actual
@@ -146,6 +148,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionNamesTest do
               %Comment{
                 type: :actionable,
                 comment: Constants.solution_function_name_snake_case(),
+                name: Constants.solution_function_name_snake_case(),
                 params: %{
                   expected: "is_registered_user",
                   actual: "isRegisteredUser"
@@ -167,6 +170,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionNamesTest do
               %Comment{
                 type: :actionable,
                 comment: Constants.solution_function_name_snake_case(),
+                name: Constants.solution_function_name_snake_case(),
                 params: %{
                   expected: "get_name",
                   actual: "getName"
@@ -188,6 +192,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionNamesTest do
               %Comment{
                 type: :actionable,
                 comment: Constants.solution_function_name_snake_case(),
+                name: Constants.solution_function_name_snake_case(),
                 params: %{
                   expected: "get_name",
                   actual: "getName"

--- a/test/elixir_analyzer/exercise_test/common_checks/indentation_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/indentation_test.exs
@@ -102,6 +102,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.IndentationTest do
                {:fail,
                 %Comment{
                   type: :informative,
+                  name: Constants.solution_indentation(),
                   comment: Constants.solution_indentation()
                 }}
              ]
@@ -122,6 +123,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.IndentationTest do
                {:fail,
                 %Comment{
                   type: :informative,
+                  name: Constants.solution_indentation(),
                   comment: Constants.solution_indentation()
                 }}
              ]
@@ -142,6 +144,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.IndentationTest do
                {:fail,
                 %Comment{
                   type: :informative,
+                  name: Constants.solution_indentation(),
                   comment: Constants.solution_indentation()
                 }}
              ]
@@ -162,6 +165,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.IndentationTest do
                {:fail,
                 %Comment{
                   type: :informative,
+                  name: Constants.solution_indentation(),
                   comment: Constants.solution_indentation()
                 }}
              ]
@@ -182,6 +186,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.IndentationTest do
                {:fail,
                 %Comment{
                   type: :informative,
+                  name: Constants.solution_indentation(),
                   comment: Constants.solution_indentation()
                 }}
              ]

--- a/test/elixir_analyzer/exercise_test/common_checks/module_attribute_names_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/module_attribute_names_test.exs
@@ -56,6 +56,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModuleAttributeNamesTest do
              {:fail,
               %Comment{
                 type: :actionable,
+                name: Constants.solution_module_attribute_name_snake_case(),
                 comment: Constants.solution_module_attribute_name_snake_case(),
                 params: %{
                   expected: "initial_value",
@@ -84,6 +85,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModuleAttributeNamesTest do
              {:fail,
               %Comment{
                 type: :actionable,
+                name: Constants.solution_module_attribute_name_snake_case(),
                 comment: Constants.solution_module_attribute_name_snake_case(),
                 params: %{
                   expected: "something_else_camel_case",

--- a/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/module_pascal_case_test.exs
@@ -43,6 +43,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
              {:fail,
               %Comment{
                 type: :actionable,
+                name: Constants.solution_module_pascal_case(),
                 comment: Constants.solution_module_pascal_case(),
                 params: %{
                   expected: "FactorialModule",
@@ -66,6 +67,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
              {:fail,
               %Comment{
                 type: :actionable,
+                name: Constants.solution_module_pascal_case(),
                 comment: Constants.solution_module_pascal_case(),
                 params: %{
                   expected: "FactorialModule",
@@ -89,6 +91,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
              {:fail,
               %Comment{
                 type: :actionable,
+                name: Constants.solution_module_pascal_case(),
                 comment: Constants.solution_module_pascal_case(),
                 params: %{
                   expected: "FactorialSubmodule",
@@ -109,6 +112,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
              {:fail,
               %Comment{
                 type: :actionable,
+                name: Constants.solution_module_pascal_case(),
                 comment: Constants.solution_module_pascal_case(),
                 params: %{
                   expected: "MyLibrary.MathOps.Factorial",
@@ -131,6 +135,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCaseTest do
              {:fail,
               %Comment{
                 type: :actionable,
+                name: Constants.solution_module_pascal_case(),
                 comment: Constants.solution_module_pascal_case(),
                 params: %{
                   expected: "MathOps.Factorial",

--- a/test/elixir_analyzer/exercise_test/common_checks/variable_names_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/variable_names_test.exs
@@ -59,6 +59,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -79,6 +80,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_other_value", actual: "someOtherValue"}
                 }}
@@ -99,6 +101,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -119,6 +122,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -139,6 +143,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -159,6 +164,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -179,6 +185,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -199,6 +206,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -219,6 +227,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "one_param", actual: "oneParam"}
                 }}
@@ -239,6 +248,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -261,6 +271,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -285,6 +296,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -309,6 +321,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -332,6 +345,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_jam", actual: "someJam"}
                 }}
@@ -356,6 +370,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "time_out", actual: "timeOut"}
                 }}
@@ -376,6 +391,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "other_param", actual: "otherParam"}
                 }}
@@ -399,6 +415,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}
@@ -419,6 +436,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNamesTest do
                {:fail,
                 %Comment{
                   type: :actionable,
+                  name: Constants.solution_variable_name_snake_case(),
                   comment: Constants.solution_variable_name_snake_case(),
                   params: %{expected: "some_value", actual: "someValue"}
                 }}

--- a/test/elixir_analyzer/exercise_test/common_checks_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks_test.exs
@@ -2,6 +2,7 @@
 # credo:disable-for-this-file Credo.Check.Readability.FunctionNames
 # credo:disable-for-this-file Credo.Check.Readability.VariableNames
 # credo:disable-for-this-file Credo.Check.Readability.ModuleNames
+# credo:disable-for-this-file Credo.Check.Warning.IoInspect
 
 defmodule ElixirAnalyzer.ExerciseTestTest.Empty do
   use ElixirAnalyzer.ExerciseTest

--- a/test/elixir_analyzer/exercise_test/common_checks_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks_test.exs
@@ -231,4 +231,39 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecksTest do
       ]
     end
   end
+
+  describe "debugging functions" do
+    test_exercise_analysis "reports IO.inspect",
+      comments: [Constants.solution_debug_functions()] do
+      [
+        defmodule Module do
+          def foo() do
+            (1 + 1)
+            |> IO.inspect()
+          end
+        end,
+        defmodule Module do
+          alias IO, as: Debug
+
+          def foo(name) do
+            Debug.inspect(name)
+          end
+        end,
+        defmodule Module do
+          import IO
+
+          def foo(name) do
+            inspect(name)
+          end
+        end,
+        defmodule Module do
+          import IO, only: [inspect: 1]
+
+          def foo(name) do
+            inspect(name)
+          end
+        end
+      ]
+    end
+  end
 end

--- a/test/elixir_analyzer/exercise_test/suppress_if_test.exs
+++ b/test/elixir_analyzer/exercise_test/suppress_if_test.exs
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Warning.IoInspect
+
 defmodule ElixirAnalyzer.ExerciseTest.SuppressIfTest do
   alias ElixirAnalyzer.Constants
 

--- a/test/elixir_analyzer/exercise_test/suppress_if_test.exs
+++ b/test/elixir_analyzer/exercise_test/suppress_if_test.exs
@@ -1,0 +1,63 @@
+defmodule ElixirAnalyzer.ExerciseTest.SuppressIfTest do
+  alias ElixirAnalyzer.Constants
+
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.Support.AnalyzerVerification.SuppressIf
+
+  test_exercise_analysis "common check is found and suppresses assert/feature 1",
+    comments: [Constants.solution_debug_functions()] do
+    defmodule MyModule do
+      def my_function() do
+        foo()
+        |> IO.inspect()
+      end
+    end
+  end
+
+  test_exercise_analysis "assert 1 and feature 1 find foo",
+    comments: ["feature 1: foo() was called", "assert 1: foo() was called"] do
+    defmodule MyModule do
+      def my_function() do
+        foo()
+      end
+    end
+  end
+
+  test_exercise_analysis "assert/feature 1 find foo and suppress assert/feature 2",
+    comments: ["feature 1: foo() was called", "assert 1: foo() was called"] do
+    defmodule MyModule do
+      def my_function() do
+        foo()
+        bar()
+      end
+    end
+  end
+
+  test_exercise_analysis "assert/feature 2 find bar",
+    comments: ["feature 2: bar() was called", "assert 2: bar() was called"] do
+    defmodule MyModule do
+      def my_function() do
+        bar()
+      end
+    end
+  end
+
+  test_exercise_analysis "assert/feature 1 find foo and suppress assert/feature 3",
+    comments: ["feature 1: foo() was called", "assert 1: foo() was called"] do
+    defmodule MyModule do
+      def my_function() do
+        foo()
+        baz()
+      end
+    end
+  end
+
+  test_exercise_analysis "assert/feature 3 find baz",
+    comments: ["feature 3: baz() was called", "assert 3: baz() was called"] do
+    defmodule MyModule do
+      def my_function() do
+        baz()
+      end
+    end
+  end
+end

--- a/test/support/analyzer_verification/suppress_if.ex
+++ b/test/support/analyzer_verification/suppress_if.ex
@@ -1,0 +1,59 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.SuppressIf do
+  @moduledoc """
+  This is an analyzer extension module to test the option :suppress_if between features/assert_call/common checks
+  """
+
+  alias ElixirAnalyzer.Constants
+  use ElixirAnalyzer.ExerciseTest
+
+  feature "feature 1: no foo() unless common check was found" do
+    find :none
+    comment "feature 1: foo() was called"
+    suppress_if Constants.solution_debug_functions(), :fail
+
+    form do
+      foo()
+    end
+  end
+
+  assert_no_call "assert 1: no foo() unless common check was found" do
+    comment "assert 1: foo() was called"
+    # This should work:
+    # suppress_if Constants.solution_debug_functions(), :fail
+    # but in assert_call, it gets treated as an AST, so the final string is required 
+    suppress_if "elixir.solution.debug_functions", :fail
+    called_fn name: :foo
+  end
+
+  feature "feature 2: no bar() unless assert 1 found a foo() first" do
+    find :none
+    comment "feature 2: bar() was called"
+    suppress_if "assert 1: no foo() unless common check was found", :fail
+
+    form do
+      bar()
+    end
+  end
+
+  assert_no_call "assert 2: no foo() unless feature 1 found a foo() first" do
+    comment "assert 2: bar() was called"
+    suppress_if "feature 1: no foo() unless common check was found", :fail
+    called_fn name: :bar
+  end
+
+  feature "feature 3: no baz() unless feature 1 found a foo() first" do
+    find :none
+    comment "feature 3: baz() was called"
+    suppress_if "feature 1: no foo() unless common check was found", :fail
+
+    form do
+      baz()
+    end
+  end
+
+  assert_no_call "assert 3: no foo() unless assert 1 found a foo() first" do
+    comment "assert 3: baz() was called"
+    suppress_if "assert 1: no foo() unless common check was found", :fail
+    called_fn name: :baz
+  end
+end


### PR DESCRIPTION
Closes #130.
This PR introduces two features

1. **A new common check for `IO.Inspect`**

This common check uses a `assert_call` under the hood to enjoy its module tracking features. 
This means that I had to add an option 
```elixir
use ElixirAnalyzer.ExerciseTest, suppress_common_tests: true
```
 because every test module runs `assert_call`, `feature` and the common checks. Since this is a common check, it would keep looping forever. 
 
Because some exercises require `IO.inspect` (`rpg-character-sheet`), I also introduced another option 
```elixir
use ElixirAnalyzer.ExerciseTest,  suppress_tests: [Constants.solution_debug_functions()]
``` 
which can suppress any type given its final comment. If that is too broad, it shouldn't be hard to suppress by the test name instead of comment (several tests can share one comment).

It would be very easy to add `IO.puts/1` to the list of debug functions. Let me know.

2. **assert_call/feature/common check cross suppress_if**

Now `feature` and `assert_call` can be suppressed by the other and by common checks. Since `suppress_if` works by checking test names, I had to add names for all common checks and test files. I picked names identical to the comments for simplicity.