### PR TITLE
[#134] `high-score` analysis should allow reset_score with remove + add player

### DIFF
--- a/lib/elixir_analyzer/test_suite/high_score.ex
+++ b/lib/elixir_analyzer/test_suite/high_score.ex
@@ -32,5 +32,14 @@ defmodule ElixirAnalyzer.TestSuite.HighScore do
     comment ElixirAnalyzer.Constants.high_score_use_module_attribute()
     calling_fn module: HighScore, name: :reset_score
     called_fn name: :@
+    suppress_if "uses add_player in reset_score", :pass
+  end
+
+  assert_call "uses add_player in reset_score" do
+    type :essential
+    comment ElixirAnalyzer.Constants.high_score_use_module_attribute()
+    calling_fn module: HighScore, name: :reset_score
+    called_fn name: :add_player
+    suppress_if "uses the module attribute in reset_score", :pass
   end
 end

--- a/test/elixir_analyzer/test_suite/high_score_test.exs
+++ b/test/elixir_analyzer/test_suite/high_score_test.exs
@@ -4,31 +4,58 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
 
   test_exercise_analysis "example solution",
     comments: [] do
-    defmodule HighScore do
-      @initial_score 0
+    [
+      defmodule HighScore do
+        @initial_score 0
 
-      def new(), do: %{}
+        def new(), do: %{}
 
-      def add_player(scores, name, score \\ @initial_score) do
-        Map.put(scores, name, score)
+        def add_player(scores, name, score \\ @initial_score) do
+          Map.put(scores, name, score)
+        end
+
+        def remove_player(scores, name) do
+          Map.delete(scores, name)
+        end
+
+        def reset_score(scores, name) do
+          Map.put(scores, name, @initial_score)
+        end
+
+        def update_score(scores, name, score) do
+          Map.update(scores, name, score, &(&1 + score))
+        end
+
+        def get_players(scores) do
+          Map.keys(scores)
+        end
+      end,
+      defmodule HighScore do
+        @initial_score 0
+
+        def new(), do: %{}
+
+        def add_player(scores, name, score \\ @initial_score) do
+          Map.put(scores, name, score)
+        end
+
+        def remove_player(scores, name) do
+          Map.delete(scores, name)
+        end
+
+        def reset_score(scores, name) do
+          scores |> remove_player(name) |> add_player(name)
+        end
+
+        def update_score(scores, name, score) do
+          Map.update(scores, name, score, &(&1 + score))
+        end
+
+        def get_players(scores) do
+          Map.keys(scores)
+        end
       end
-
-      def remove_player(scores, name) do
-        Map.delete(scores, name)
-      end
-
-      def reset_score(scores, name) do
-        Map.put(scores, name, @initial_score)
-      end
-
-      def update_score(scores, name, score) do
-        Map.update(scores, name, score, &(&1 + score))
-      end
-
-      def get_players(scores) do
-        Map.keys(scores)
-      end
-    end
+    ]
   end
 
   test_exercise_analysis "requires add_player to have a default argument that's a module attribute",


### PR DESCRIPTION
Fixes #134. 
Easy-peasy. Make both conditions suppress if the other passes.
I think this doesn't generalize to more than 2 conditions, though. If there is a need for that, we may need to generalize `assert_call` to make the following valid:
```elixir
  assert_call "uses the module attribute in reset_score or indirectly via add_player" do
    type :essential
    comment ElixirAnalyzer.Constants.high_score_use_module_attribute()
    find: any # :one, :all, :none ?
    
    call do
      calling_fn module: HighScore, name: :reset_score
      called_fn name: :@
    end

    call do
      calling_fn module: HighScore, name: :reset_score
      called_fn name: :add_player
    end
  end
```