### PR TITLE
[#139] Bug -- `RPG.CharacterSheet` false-positive error

### DIFF
--- a/test/elixir_analyzer/exercise_test/feature/block_ends_with_test.exs
+++ b/test/elixir_analyzer/exercise_test/feature/block_ends_with_test.exs
@@ -394,6 +394,44 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.BlockEndsWithTest do
     ]
   end
 
+  test_exercise_analysis "code with a block finishing on a function with pipes",
+    comments_exclude: ["cannot detect a block finishing on a function"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          final_function(:ok)
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          :ok |> final_function()
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          :ok |> baz(:error) |> final_function()
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "code with a block not finishing on a function with pipes",
+    comments_include: ["cannot detect a block finishing on a function"] do
+    [
+      defmodule MyModule do
+        def foo() do
+          final_function(:ok)
+          :super_final
+        end
+      end,
+      defmodule MyModule do
+        def foo() do
+          :ok |> final_function() |> super_final()
+        end
+      end
+    ]
+  end
+
   test_exercise_analysis "code with nested blocks",
     comments_exclude: ["cannot detect nested blocks"] do
     [

--- a/test/elixir_analyzer/exercise_test/feature/pipes_test.exs
+++ b/test/elixir_analyzer/exercise_test/feature/pipes_test.exs
@@ -1,0 +1,184 @@
+defmodule ElixirAnalyzer.ExerciseTest.Feature.PipesTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.Support.AnalyzerVerification.Feature.Pipes
+
+  test_exercise_analysis "function with one parameter",
+    comments_exclude: ["not one parameter"] do
+    [
+      defmodule MyModule do
+        def hi(name) do
+          foo(name)
+        end
+      end,
+      # This case matches, because feature looks down the AST
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo(:ok)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo()
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> String.downcase() |> foo()
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> String.downcase() |> foo
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "function not with one parameter",
+    comments_include: ["not one parameter"] do
+    [
+      defmodule MyModule do
+        def hi(name) do
+          foo()
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          foo
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "function with three parameter",
+    comments_exclude: ["not three parameter"] do
+    [
+      defmodule MyModule do
+        def hi(name) do
+          foo(name, :ok, false)
+        end
+      end,
+      # This case matches, because feature looks down the AST
+      defmodule MyModule do
+        def hi(name) do
+          :woops |> foo(name, :ok, false)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo(:ok, false)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> String.downcase() |> foo(:ok, false)
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "function not with three parameter",
+    comments_include: ["not three parameter"] do
+    [
+      defmodule MyModule do
+        def hi(name) do
+          foo(name, false)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo(false)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> String.downcase() |> foo
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "function with one piped parameter",
+    comments_exclude: ["not one piped parameter", "not one piped parameter (no parens)"] do
+    [
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo()
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> String.downcase() |> foo()
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> String.downcase() |> foo
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "function not with one piped parameter",
+    comments_include: ["not one piped parameter", "not one piped parameter (no parens)"] do
+    [
+      defmodule MyModule do
+        def hi(name) do
+          foo(name)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo(:ok)
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "function with three parameter and one piped",
+    comments_exclude: ["not three parameters with one piped"] do
+    [
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo(:ok, false)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> String.downcase() |> foo(:ok, false)
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "function not with three parameter and one piped",
+    comments_include: ["not three parameters with one piped"] do
+    [
+      defmodule MyModule do
+        def hi(name) do
+          foo(name, :ok, false)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> foo(:ok)
+        end
+      end,
+      defmodule MyModule do
+        def hi(name) do
+          name |> String.downcase() |> foo(:ok)
+        end
+      end
+    ]
+  end
+end

--- a/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
+++ b/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
@@ -6,42 +6,75 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheetTest do
 
   test_exercise_analysis "example solution",
     comments: [] do
-    defmodule RPG.CharacterSheet do
-      def welcome() do
-        IO.puts("Welcome! Let's fill out your character sheet together.")
+    [
+      defmodule RPG.CharacterSheet do
+        def welcome() do
+          IO.puts("Welcome! Let's fill out your character sheet together.")
+        end
+
+        def ask_name() do
+          name = IO.gets("What is your character's name?\n")
+          String.trim(name)
+        end
+
+        def ask_class() do
+          name = IO.gets("What is your character's class?\n")
+          String.trim(name)
+        end
+
+        def ask_level() do
+          level = IO.gets("What is your character's level?\n")
+          level = String.trim(level)
+          String.to_integer(level)
+        end
+
+        def run() do
+          welcome()
+          name = ask_name()
+          class = ask_class()
+          level = ask_level()
+
+          character = %{
+            name: name,
+            class: class,
+            level: level
+          }
+
+          IO.inspect(character, label: "Your character")
+        end
+      end,
+      defmodule RPG.CharacterSheet do
+        def welcome() do
+          IO.puts("Welcome! Let's fill out your character sheet together.")
+        end
+
+        def ask_name() do
+          IO.gets("What is your character's name?\n") |> String.trim()
+        end
+
+        def ask_class() do
+          IO.gets("What is your character's class?\n") |> String.trim()
+        end
+
+        def ask_level() do
+          IO.gets("What is your character's level?\n") |> String.trim() |> String.to_integer()
+        end
+
+        def run() do
+          welcome()
+          name = ask_name()
+          class = ask_class()
+          level = ask_level()
+
+          %{
+            name: name,
+            class: class,
+            level: level
+          }
+          |> IO.inspect(label: "Your character")
+        end
       end
-
-      def ask_name() do
-        name = IO.gets("What is your character's name?\n")
-        String.trim(name)
-      end
-
-      def ask_class() do
-        name = IO.gets("What is your character's class?\n")
-        String.trim(name)
-      end
-
-      def ask_level() do
-        level = IO.gets("What is your character's level?\n")
-        level = String.trim(level)
-        String.to_integer(level)
-      end
-
-      def run() do
-        welcome()
-        name = ask_name()
-        class = ask_class()
-        level = ask_level()
-
-        character = %{
-          name: name,
-          class: class,
-          level: level
-        }
-
-        IO.inspect(character, label: "Your character")
-      end
-    end
+    ]
   end
 
   describe "implicit :ok return" do

--- a/test/support/analyzer_verification/feature/block_ends_with.ex
+++ b/test/support/analyzer_verification/feature/block_ends_with.ex
@@ -57,6 +57,19 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.Feature.BlockEndsWith do
     end
   end
 
+  feature "can detect a block finishing on a function" do
+    type :essential
+    comment "cannot detect a block finishing on a function"
+
+    form do
+      def foo() do
+        _block_ends_with do
+          final_function(_ignore)
+        end
+      end
+    end
+  end
+
   feature "can detect nested blocks" do
     type :essential
     comment "cannot detect nested blocks"

--- a/test/support/analyzer_verification/feature/pipes.ex
+++ b/test/support/analyzer_verification/feature/pipes.ex
@@ -1,0 +1,52 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.Feature.Pipes do
+  @moduledoc """
+  This is an exercise analyzer extension module to test feature specifically on pipes 
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+
+  feature "function with one parameter" do
+    type :essential
+    comment "not one parameter"
+
+    form do
+      foo(_ignore)
+    end
+  end
+
+  feature "function with three parameter" do
+    type :essential
+    comment "not three parameter"
+
+    form do
+      foo(_ignore, _ignore, _ignore)
+    end
+  end
+
+  feature "function with one piped parameter" do
+    type :essential
+    comment "not one piped parameter"
+
+    form do
+      _ignore |> foo()
+    end
+  end
+
+  feature "function with one piped parameter (no parens)" do
+    type :essential
+    comment "not one piped parameter (no parens)"
+
+    form do
+      _ignore |> foo
+    end
+  end
+
+  feature "function with three parameters with one piped" do
+    type :essential
+    comment "not three parameters with one piped"
+
+    form do
+      _ignore |> foo(_ignore, _ignore)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #139.

This was fairly tricky, please review with care.

Because the case raised by @neenjaw is likely to happen regularly, I chose to treat pipes as a special case throughout all `feature` matches, not just for `_block_ends_with`. I came up with those rules:

1. If there is a pipe in the `form`, there must be a pipe in the code.
2. If there is no pipe in the `form` but a pipe in the code, the pipe in the code will get "unpiped" go on with the match.

I dealt with one edge case: even `mix format` allows both `:ok |> foo` and `:ok |> foo()` so I made sure that didn't matter for the `form` or the code.

I noticed another edge case: if the form is `foo(_ignore)`, then `name |> foo(:ok)` will unfortunately match, because `feature` goes down the AST and tries to match beyond the pipe. So this PR is not rainbow-unicorn-magic  (🌈🦄🧙‍♀️) good, although to be fair, this is the current behavior anyway, so no existing test can break from this.

I added tests for all of these points.