### PR TITLE
[#146] Missing parenthesis in zero-arity function definitions cause false-positives

### DIFF
--- a/lib/elixir_analyzer/exercise_test/feature/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/feature/compiler.ex
@@ -225,25 +225,24 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.Compiler do
     end
   end
 
+  # functions called with or without parentheses should match
+  def form_match?({function, form_params, []}, {function, params, atom}) when is_atom(atom) do
+    form_match?(form_params, params)
+  end
+
+  def form_match?({function, form_params, atom}, {function, params, []}) when is_atom(atom) do
+    form_match?(form_params, params)
+  end
+
   # Pipes are a special case, when pipes are in the form, they must be in the code
-  def form_match?({:|>, form_meta, [form_params, form_function]}, line) do
-    case line do
-      {:|>, meta, [params, function]} ->
-        form_function = add_parens_to_end_of_pipe(form_function)
-        function = add_parens_to_end_of_pipe(function)
-
-        form_match?(form_meta, meta) and form_match?(form_params, params) and
-          form_match?(form_function, function)
-
-      _ ->
-        false
-    end
+  def form_match?({:|>, form_meta, form_params}, {:|>, meta, params}) do
+    form_match?(form_meta, meta) and form_match?(form_params, params)
   end
 
   # When pipes are not in the form but in the code, we un-pipe the code
   def form_match?(form_params, {:|>, _, [params, {function, function_meta, function_params}]}) do
     if is_atom(function_params) do
-      form_match?(form_params, {function, function_meta, List.wrap(params)})
+      form_match?(form_params, {function, function_meta, [params]})
     else
       form_match?(form_params, {function, function_meta, [params | function_params]})
     end
@@ -282,13 +281,5 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.Compiler do
 
   defp all_forms_are_found?(form_params, _params) when is_list(form_params) do
     false
-  end
-
-  defp add_parens_to_end_of_pipe({name, meta, module}) when is_atom(module) do
-    {name, meta, []}
-  end
-
-  defp add_parens_to_end_of_pipe(node) do
-    node
   end
 end

--- a/test/elixir_analyzer/exercise_test/assert_call/function_parentheses_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call/function_parentheses_test.exs
@@ -1,0 +1,90 @@
+defmodule ElixirAnalyzer.ExerciseTest.AssertCall.FunctionParenthesesTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module:
+      ElixirAnalyzer.Support.AnalyzerVerification.AssertCall.FunctionParentheses
+
+  test_exercise_analysis "defining run/0",
+    comments_exclude: [
+      "did not match def run()",
+      "did not match def run"
+    ] do
+    [
+      defmodule MyModule do
+        def run do
+          :ok
+        end
+      end,
+      defmodule MyModule do
+        def run() do
+          :ok
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "assigning run/0",
+    comments_exclude: [
+      "did not match run()",
+      "did not match run"
+    ] do
+    [
+      defmodule MyModule do
+        def sprint() do
+          a = run()
+        end
+      end,
+      defmodule MyModule do
+        def sprint() do
+          a = run
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "using run/0 in a pipe",
+    comments_exclude: [
+      "did not match run() in a pipe",
+      "did not match run in a pipe"
+    ] do
+    [
+      defmodule MyModule do
+        def sprint() do
+          a = :start |> run()
+        end
+      end,
+      defmodule MyModule do
+        def sprint() do
+          a = :start |> run() |> jump()
+        end
+      end,
+      defmodule MyModule do
+        def sprint() do
+          a = :start |> run
+        end
+      end,
+      defmodule MyModule do
+        def sprint() do
+          a = :start |> run |> jump()
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "not using any run/0",
+    comments_include: [
+      "did not match def run()",
+      "did not match def run",
+      "did not match run()",
+      "did not match run",
+      "did not match run() in a pipe",
+      "did not match run in a pipe"
+    ] do
+    [
+      defmodule MyModule do
+        def sprint() do
+          a = :start |> sprint() |> jump()
+        end
+      end
+    ]
+  end
+end

--- a/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
+++ b/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
@@ -73,6 +73,72 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheetTest do
           }
           |> IO.inspect(label: "Your character")
         end
+      end,
+      defmodule RPG.CharacterSheet do
+        @moduledoc """
+        A collection of functions related to creating a character sheet.
+        """
+
+        @doc """
+        Prints out the welcome message.
+        """
+        @spec welcome() :: binary()
+
+        def welcome do
+          IO.puts("Welcome! Let's fill out your character sheet together.")
+        end
+
+        @doc """
+        Gets the character name via input.
+        """
+        @spec ask_name() :: binary()
+
+        def ask_name do
+          ask("What is your character's name?\n")
+        end
+
+        @doc """
+        Gets the character class via input.
+        """
+        @spec ask_class() :: binary()
+
+        def ask_class do
+          ask("What is your character's class?\n")
+        end
+
+        @doc """
+        Gets the character's level via input, returns an integer.
+        """
+        @spec ask_level() :: pos_integer()
+
+        def ask_level do
+          "What is your character's level?\n"
+          |> ask()
+          |> String.to_integer(10)
+        end
+
+        @doc """
+        Runs the character sheet creation workflow.
+        """
+        @spec run() :: %{name: binary(), class: binary(), level: pos_integer()}
+
+        def run do
+          welcome()
+
+          %{
+            name: ask_name(),
+            class: ask_class(),
+            level: ask_level()
+          }
+          |> IO.inspect(label: "Your character")
+        end
+
+        # Given a question, asks it and trims leading & trailing whitespaces.
+        defp ask(question) do
+          question
+          |> IO.gets()
+          |> String.trim()
+        end
       end
     ]
   end

--- a/test/support/analyzer_verification/assert_call/function_parentheses.ex
+++ b/test/support/analyzer_verification/assert_call/function_parentheses.ex
@@ -1,0 +1,66 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.AssertCall.FunctionParentheses do
+  @moduledoc """
+  This is an exercise analyzer extension module to test that feature accepts function calls of
+  arity 0 with or without parentheses
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+
+  feature "run/0 defined with run()" do
+    type :essential
+    comment "did not match def run()"
+
+    form do
+      def run() do
+        _ignore
+      end
+    end
+  end
+
+  feature "run/0 defined with run" do
+    type :essential
+    comment "did not match def run"
+
+    form do
+      def run do
+        _ignore
+      end
+    end
+  end
+
+  feature "run/0 used with run()" do
+    type :essential
+    comment "did not match run()"
+
+    form do
+      _ignore = run()
+    end
+  end
+
+  feature "run/0 used with run" do
+    type :essential
+    comment "did not match run"
+
+    form do
+      _ignore = run
+    end
+  end
+
+  feature "run/0 used with run() in a pipe" do
+    type :essential
+    comment "did not match run() in a pipe"
+
+    form do
+      _ignore |> run()
+    end
+  end
+
+  feature "run/0 used with run in a pipe" do
+    type :essential
+    comment "did not match run in a pipe"
+
+    form do
+      _ignore |> run
+    end
+  end
+end


### PR DESCRIPTION
Fixes #146.

From this PR, `a` will always be treated to be equivalent with `a()` in a `feature`, and match both `a` and `a()` in code.

There was already some code that did this for the special case of pipes, but I removed it since this is more general. 