### PR TITLE
Detect assignment on last line of function/macro definition

### DIFF
--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -24,6 +24,7 @@ defmodule ElixirAnalyzer.Constants do
     solution_variable_name_snake_case: "elixir.solution.variable_name_snake_case",
     solution_indentation: "elixir.solution.indentation",
     solution_debug_functions: "elixir.solution.debug_functions",
+    solution_last_line_assignment: "elixir.solution.last_line_assignment",
 
     # Concept exercises
 

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -14,6 +14,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
   defmacro __using__(_opts) do
     quote do
       use ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions
+      use ElixirAnalyzer.ExerciseTest.CommonChecks.LastLineAssignment
     end
   end
 

--- a/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
@@ -1,6 +1,6 @@
 defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions do
   @moduledoc """
-  This is an exercise analyzer extension module used for common tests lookin for debugging functions
+  This is an exercise analyzer extension module used for common tests looking for debugging functions
   """
 
   defmacro __using__(_opts) do

--- a/lib/elixir_analyzer/exercise_test/common_checks/last_line_assignment.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/last_line_assignment.ex
@@ -1,0 +1,50 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.LastLineAssignment do
+  @moduledoc """
+  This is an exercise analyzer extension module used for common tests looking for assignments
+  on the last line of function definitions
+  """
+
+  alias ElixirAnalyzer.Constants
+
+  defmacro __using__(_opts) do
+    quote do
+      feature Constants.solution_last_line_assignment() do
+        type :informative
+        comment Constants.solution_last_line_assignment()
+        find :none
+
+        form do
+          def _ignore do
+            _block_ends_with do
+              _ignore = _ignore
+            end
+          end
+        end
+
+        form do
+          defp _ignore do
+            _block_ends_with do
+              _ignore = _ignore
+            end
+          end
+        end
+
+        form do
+          defmacro _ignore do
+            _block_ends_with do
+              _ignore = _ignore
+            end
+          end
+        end
+
+        form do
+          defmacrop _ignore do
+            _block_ends_with do
+              _ignore = _ignore
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/elixir_analyzer/exercise_test/assert_call/erlang_modules_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call/erlang_modules_test.exs
@@ -7,27 +7,26 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in function/0",
       "found a call to :rand in module",
       "found a call to :rand.normal in function/0",
-      "found a call to :rand.normal in module",
-      "elixir.solution.last_line_assignment"
+      "found a call to :rand.normal in module"
     ] do
     [
       defmodule AssertCallVerification do
         def function() do
-          r = :rand.normal()
+          :rand.normal()
         end
       end,
       defmodule AssertCallVerification do
         alias :rand, as: Rand
 
         def function() do
-          r = Rand.normal()
+          Rand.normal()
         end
       end,
       defmodule AssertCallVerification do
         alias :rand
 
         def function() do
-          r = :rand.normal()
+          :rand.normal()
         end
       end
     ]
@@ -38,22 +37,21 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in function/0",
       "found a call to :rand in module",
       "found a call to :rand.normal in function/0",
-      "found a call to :rand.normal in module",
-      "elixir.solution.last_line_assignment"
+      "found a call to :rand.normal in module"
     ] do
     [
       defmodule AssertCallVerification do
         import :rand
 
         def function() do
-          r = normal()
+          normal()
         end
       end,
       defmodule AssertCallVerification do
         import :rand, only: [normal: 0]
 
         def function() do
-          r = normal()
+          normal()
         end
       end,
       defmodule AssertCallVerification do
@@ -61,14 +59,14 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
 
         def function() do
           import :rand, only: [normal: 0]
-          r = normal()
+          normal()
         end
       end,
       defmodule AssertCallVerification do
         import :rand, only: :functions
 
         def function() do
-          r = normal()
+          normal()
         end
       end
     ]
@@ -79,26 +77,21 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in module",
       "found a call to :rand.normal in module",
       "didn't find a call to :rand.normal/0 in function/0",
-      "didn't find a call to a :rand function in function/0",
-      "elixir.solution.last_line_assignment"
+      "didn't find a call to a :rand function in function/0"
     ] do
     [
       defmodule AssertCallVerification do
         def function() do
         end
 
-        def other_funtion() do
-          r = :rand.normal()
-        end
+        :rand.normal()
       end,
       defmodule AssertCallVerification do
         def function() do
           import :rand, except: [normal: 0]
         end
 
-        def other_funtion() do
-          r = :rand.normal()
-        end
+        :rand.normal()
       end
     ]
   end
@@ -108,12 +101,11 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in function/0",
       "found a call to :rand in module",
       "didn't find a call to :rand.normal anywhere in module",
-      "didn't find a call to :rand.normal/0 in function/0",
-      "elixir.solution.last_line_assignment"
+      "didn't find a call to :rand.normal/0 in function/0"
     ] do
     defmodule AssertCallVerification do
       def function() do
-        r = :rand.uniform()
+        :rand.uniform()
       end
     end
   end
@@ -123,16 +115,13 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in module",
       "didn't find a call to :rand.normal anywhere in module",
       "didn't find a call to :rand.normal/0 in function/0",
-      "didn't find a call to a :rand function in function/0",
-      "elixir.solution.last_line_assignment"
+      "didn't find a call to a :rand function in function/0"
     ] do
     defmodule AssertCallVerification do
       def function() do
       end
 
-      def other_funtion() do
-        r = :rand.uniform()
-      end
+      :rand.uniform()
     end
   end
 

--- a/test/elixir_analyzer/exercise_test/assert_call/erlang_modules_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call/erlang_modules_test.exs
@@ -7,7 +7,8 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in function/0",
       "found a call to :rand in module",
       "found a call to :rand.normal in function/0",
-      "found a call to :rand.normal in module"
+      "found a call to :rand.normal in module",
+      "elixir.solution.last_line_assignment"
     ] do
     [
       defmodule AssertCallVerification do
@@ -37,7 +38,8 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in function/0",
       "found a call to :rand in module",
       "found a call to :rand.normal in function/0",
-      "found a call to :rand.normal in module"
+      "found a call to :rand.normal in module",
+      "elixir.solution.last_line_assignment"
     ] do
     [
       defmodule AssertCallVerification do
@@ -77,21 +79,26 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in module",
       "found a call to :rand.normal in module",
       "didn't find a call to :rand.normal/0 in function/0",
-      "didn't find a call to a :rand function in function/0"
+      "didn't find a call to a :rand function in function/0",
+      "elixir.solution.last_line_assignment"
     ] do
     [
       defmodule AssertCallVerification do
         def function() do
         end
 
-        r = :rand.normal()
+        def other_funtion() do
+          r = :rand.normal()
+        end
       end,
       defmodule AssertCallVerification do
         def function() do
           import :rand, except: [normal: 0]
         end
 
-        r = :rand.normal()
+        def other_funtion() do
+          r = :rand.normal()
+        end
       end
     ]
   end
@@ -101,7 +108,8 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in function/0",
       "found a call to :rand in module",
       "didn't find a call to :rand.normal anywhere in module",
-      "didn't find a call to :rand.normal/0 in function/0"
+      "didn't find a call to :rand.normal/0 in function/0",
+      "elixir.solution.last_line_assignment"
     ] do
     defmodule AssertCallVerification do
       def function() do
@@ -115,13 +123,16 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
       "found a call to :rand in module",
       "didn't find a call to :rand.normal anywhere in module",
       "didn't find a call to :rand.normal/0 in function/0",
-      "didn't find a call to a :rand function in function/0"
+      "didn't find a call to a :rand function in function/0",
+      "elixir.solution.last_line_assignment"
     ] do
     defmodule AssertCallVerification do
       def function() do
       end
 
-      r = :rand.uniform()
+      def other_funtion() do
+        r = :rand.uniform()
+      end
     end
   end
 
@@ -141,7 +152,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.ErlangTest do
         import :rand, except: [normal: 0]
 
         def function() do
-          r = normal()
+          normal()
         end
       end
     ]

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -162,7 +162,8 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
     comments: [
       "didn't find a call to a List function",
       "didn't find a call to a List function in function/0",
-      "mock.constant"
+      "mock.constant",
+      "elixir.solution.last_line_assignment"
     ] do
     defmodule AssertCallVerification do
       def function() do

--- a/test/elixir_analyzer/exercise_test/common_checks/last_line_assignment_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/last_line_assignment_test.exs
@@ -1,0 +1,83 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.LastLineAssignment do
+  use ElixirAnalyzer.ExerciseTest
+end
+
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.LastLineAssignmentTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.Support.AnalyzerVerification.LastLineAssignment
+
+  alias ElixirAnalyzer.Constants
+
+  test_exercise_analysis "Solutions without a last line assignment",
+    comments: [] do
+    [
+      defmodule MyModule do
+        def ok() do
+          :ok
+        end
+
+        defp two() do
+          two = 1 + 1
+          two
+        end
+
+        defmacro nothing() do
+          a = nil
+
+          quote do
+            unquote(a)
+          end
+        end
+
+        defmacrop add_macro() do
+          a = 1 + 1
+
+          quote do
+            unquote(a)
+          end
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "Solutions with a last line assignment",
+    comments: [Constants.solution_last_line_assignment()] do
+    [
+      defmodule MyModule do
+        def ok() do
+          a = :ok
+        end
+      end,
+      defmodule MyModule do
+        def ok() do
+          a = :ok |> Atom.to_string()
+        end
+      end,
+      defmodule MyModule do
+        defp two() do
+          _a = 1 + 1
+        end
+      end,
+      defmodule MyModule do
+        defmacro nothing() do
+          a = nil
+
+          quote =
+            quote do
+              unquote(a)
+            end
+        end
+      end,
+      defmodule MyModule do
+        defmacrop add_macro() do
+          a = 1 + 1
+
+          _quote =
+            quote do
+              unquote(a)
+            end
+        end
+      end
+    ]
+  end
+end


### PR DESCRIPTION
Closes #144.
Well... Sort of.

This PR introduces a new common check: checking if a function ends with an assignment.

With this PR, @hunkyjimpjorps 's code would show 3 warnings: the existing 2 "`run/0` should end with..." and a new one "assignment on last line" (to be added in website-copy after discussion). Fixing the last one fixes all warnings, but is confusing to see 3 errors when there is only one.

Should we:
1.  suppress the first two checks if "assignment on last line" is detected?  That might not be perfect either because all mistakes can be done at the same time. It would then take two rounds to fix mistakes. It would also be tricky because many exercises have this type of check.
2. add a description for the last line assignment with something of the effect of "Last line assignments are known to throw the analyzer off balance, fix that first to see if it helps with other warnings"?
3. quit everything and become plumbers in Micronesia?

3 is a bit extreme, but I'm open to suggestions.