### PR TITLE
Fix `assert_call` AST arguments bug

### DIFF
--- a/lib/elixir_analyzer/exercise_test/assert_call.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call.ex
@@ -43,14 +43,16 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall do
       |> Map.put(:should_call, should_call)
       |> Map.put_new(:type, :informative)
       |> Map.put_new(:calling_fn, nil)
+      # made into a key-val list for better quoting
+      |> Map.to_list()
 
-    unless Map.has_key?(test_data, :comment) do
+    unless Keyword.has_key?(test_data, :comment) do
       raise "Comment must be defined for each assert_call test"
     end
 
     quote do
       @assert_call_tests [
-        unquote(Macro.escape(test_data)) | @assert_call_tests
+        unquote(test_data) | @assert_call_tests
       ]
     end
   end

--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -10,13 +10,13 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
   alias ElixirAnalyzer.Comment
 
   def compile(assert_call_data, code_ast) do
-    name = assert_call_data.description
-    called_fn = Macro.escape(assert_call_data.called_fn)
-    calling_fn = Macro.escape(assert_call_data.calling_fn)
-    {comment, _} = Code.eval_quoted(assert_call_data.comment)
-    should_call = assert_call_data.should_call
-    type = assert_call_data.type
-    suppress_if = Map.get(assert_call_data, :suppress_if, false)
+    name = Keyword.fetch!(assert_call_data, :description)
+    called_fn = Keyword.fetch!(assert_call_data, :called_fn)
+    calling_fn = Keyword.fetch!(assert_call_data, :calling_fn)
+    comment = Keyword.fetch!(assert_call_data, :comment)
+    should_call = Keyword.fetch!(assert_call_data, :should_call)
+    type = Keyword.fetch!(assert_call_data, :type)
+    suppress_if = Keyword.get(assert_call_data, :suppress_if, false)
 
     test_description =
       Macro.escape(%Comment{

--- a/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
@@ -3,11 +3,13 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions do
   This is an exercise analyzer extension module used for common tests looking for debugging functions
   """
 
+  alias ElixirAnalyzer.Constants
+
   defmacro __using__(_opts) do
     quote do
-      assert_no_call unquote(ElixirAnalyzer.Constants.solution_debug_functions()) do
+      assert_no_call Constants.solution_debug_functions() do
         type :informative
-        comment ElixirAnalyzer.Constants.solution_debug_functions()
+        comment Constants.solution_debug_functions()
         called_fn module: IO, name: :inspect
       end
     end

--- a/lib/elixir_analyzer/exercise_test/common_checks/uncommon_errors.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/uncommon_errors.ex
@@ -2,13 +2,14 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.UncommonErrors do
   @moduledoc """
   This is an exercise analyzer extension module used for common tests looking for uncommon errors raised
   """
+  alias ElixirAnalyzer.Constants
 
   defmacro __using__(_opts) do
     quote do
-      feature "raises function clause error" do
+      feature Constants.solution_raise_fn_clause_error() do
         find :none
         type :actionable
-        comment ElixirAnalyzer.Constants.solution_raise_fn_clause_error()
+        comment Constants.solution_raise_fn_clause_error()
 
         form do
           raise FunctionClauseError

--- a/lib/elixir_analyzer/exercise_test/feature/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/feature/compiler.ex
@@ -7,7 +7,7 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.Compiler do
 
   def compile({feature_data, feature_forms}, code_ast) do
     name = Keyword.fetch!(feature_data, :name)
-    {comment, _} = Code.eval_quoted(Keyword.fetch!(feature_data, :comment))
+    comment = Keyword.fetch!(feature_data, :comment)
     status = Keyword.get(feature_data, :status, :test)
     type = Keyword.get(feature_data, :type, :informative)
     find_type = Keyword.get(feature_data, :find, :all)

--- a/lib/elixir_analyzer/test_suite/accumulate.ex
+++ b/lib/elixir_analyzer/test_suite/accumulate.ex
@@ -4,28 +4,29 @@ defmodule ElixirAnalyzer.TestSuite.Accumulate do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_no_call "does not call any Enum functions" do
     type :essential
     called_fn module: Enum, name: :_
-    comment ElixirAnalyzer.Constants.accumulate_use_recursion()
+    comment Constants.accumulate_use_recursion()
   end
 
   assert_no_call "does not call any Stream functions" do
     type :essential
     called_fn module: Stream, name: :_
-    comment ElixirAnalyzer.Constants.accumulate_use_recursion()
+    comment Constants.accumulate_use_recursion()
   end
 
   assert_no_call "does not call any List functions" do
     type :essential
     called_fn module: List, name: :_
-    comment ElixirAnalyzer.Constants.accumulate_use_recursion()
+    comment Constants.accumulate_use_recursion()
   end
 
   assert_no_call "doesn't use list comprehensions" do
     type :essential
     called_fn name: :for
-    comment ElixirAnalyzer.Constants.accumulate_use_recursion()
+    comment Constants.accumulate_use_recursion()
   end
 end

--- a/lib/elixir_analyzer/test_suite/bird_count.ex
+++ b/lib/elixir_analyzer/test_suite/bird_count.ex
@@ -4,28 +4,29 @@ defmodule ElixirAnalyzer.TestSuite.BirdCount do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_no_call "does not call any Enum functions" do
     type :essential
     called_fn module: Enum, name: :_
-    comment ElixirAnalyzer.Constants.bird_count_use_recursion()
+    comment Constants.bird_count_use_recursion()
   end
 
   assert_no_call "does not call any Stream functions" do
     type :essential
     called_fn module: Stream, name: :_
-    comment ElixirAnalyzer.Constants.bird_count_use_recursion()
+    comment Constants.bird_count_use_recursion()
   end
 
   assert_no_call "does not call any List functions" do
     type :essential
     called_fn module: List, name: :_
-    comment ElixirAnalyzer.Constants.bird_count_use_recursion()
+    comment Constants.bird_count_use_recursion()
   end
 
   assert_no_call "doesn't use list comprehensions" do
     type :essential
     called_fn name: :for
-    comment ElixirAnalyzer.Constants.bird_count_use_recursion()
+    comment Constants.bird_count_use_recursion()
   end
 end

--- a/lib/elixir_analyzer/test_suite/boutique_suggestions.ex
+++ b/lib/elixir_analyzer/test_suite/boutique_suggestions.ex
@@ -4,28 +4,29 @@ defmodule ElixirAnalyzer.TestSuite.BoutiqueSuggestions do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_call "uses list comprehensions" do
     type :essential
     called_fn name: :for
-    comment ElixirAnalyzer.Constants.boutique_suggestions_use_list_comprehensions()
+    comment Constants.boutique_suggestions_use_list_comprehensions()
   end
 
   assert_no_call "does not call any Enum functions" do
     type :essential
     called_fn module: Enum, name: :_
-    comment ElixirAnalyzer.Constants.boutique_suggestions_use_list_comprehensions()
+    comment Constants.boutique_suggestions_use_list_comprehensions()
   end
 
   assert_no_call "does not call any Stream functions" do
     type :essential
     called_fn module: Stream, name: :_
-    comment ElixirAnalyzer.Constants.boutique_suggestions_use_list_comprehensions()
+    comment Constants.boutique_suggestions_use_list_comprehensions()
   end
 
   assert_no_call "does not call any List functions" do
     type :essential
     called_fn module: List, name: :_
-    comment ElixirAnalyzer.Constants.boutique_suggestions_use_list_comprehensions()
+    comment Constants.boutique_suggestions_use_list_comprehensions()
   end
 end

--- a/lib/elixir_analyzer/test_suite/chessboard.ex
+++ b/lib/elixir_analyzer/test_suite/chessboard.ex
@@ -4,24 +4,25 @@ defmodule ElixirAnalyzer.TestSuite.Chessboard do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_call "ranks calls rank_range" do
     type :actionable
-    comment ElixirAnalyzer.Constants.chessboard_function_reuse()
+    comment Constants.chessboard_function_reuse()
     called_fn name: :rank_range
     calling_fn module: Chessboard, name: :ranks
   end
 
   assert_call "files calls file_range" do
     type :actionable
-    comment ElixirAnalyzer.Constants.chessboard_function_reuse()
+    comment Constants.chessboard_function_reuse()
     called_fn name: :file_range
     calling_fn module: Chessboard, name: :files
   end
 
   feature "change codepoint to string directly" do
     type :actionable
-    comment ElixirAnalyzer.Constants.chessboard_change_codepoint_to_string_directly()
+    comment Constants.chessboard_change_codepoint_to_string_directly()
 
     form do
       <<_ignore>>

--- a/lib/elixir_analyzer/test_suite/freelancer_rates.ex
+++ b/lib/elixir_analyzer/test_suite/freelancer_rates.ex
@@ -4,18 +4,19 @@ defmodule ElixirAnalyzer.TestSuite.FreelancerRates do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_call "monthly_rate/2 reuses apply_discount/2" do
     type :actionable
     calling_fn module: FreelancerRates, name: :monthly_rate
     called_fn name: :apply_discount
-    comment ElixirAnalyzer.Constants.freelancer_rates_apply_discount_function_reuse()
+    comment Constants.freelancer_rates_apply_discount_function_reuse()
   end
 
   assert_call "days_in_budget/2 reuses apply_discount/2" do
     type :actionable
     calling_fn module: FreelancerRates, name: :days_in_budget
     called_fn name: :apply_discount
-    comment ElixirAnalyzer.Constants.freelancer_rates_apply_discount_function_reuse()
+    comment Constants.freelancer_rates_apply_discount_function_reuse()
   end
 end

--- a/lib/elixir_analyzer/test_suite/german_sysadmin.ex
+++ b/lib/elixir_analyzer/test_suite/german_sysadmin.ex
@@ -4,34 +4,35 @@ defmodule ElixirAnalyzer.TestSuite.GermanSysadmin do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_no_call "doesn't convert anything to a string" do
     type :essential
     called_fn name: :to_string
-    comment ElixirAnalyzer.Constants.german_sysadmin_no_string()
+    comment Constants.german_sysadmin_no_string()
   end
 
   assert_no_call "doesn't convert anything to a charlist" do
     type :essential
     called_fn name: :to_charlist
-    comment ElixirAnalyzer.Constants.german_sysadmin_no_string()
+    comment Constants.german_sysadmin_no_string()
   end
 
   assert_no_call "doesn't use any string functions" do
     type :essential
     called_fn module: String, name: :_
-    comment ElixirAnalyzer.Constants.german_sysadmin_no_string()
+    comment Constants.german_sysadmin_no_string()
   end
 
   assert_no_call "doesn't create binaries from character codes" do
     type :essential
     called_fn name: :<<>>
-    comment ElixirAnalyzer.Constants.german_sysadmin_no_string()
+    comment Constants.german_sysadmin_no_string()
   end
 
   assert_call "using case is required" do
     type :essential
     called_fn name: :case
-    comment ElixirAnalyzer.Constants.german_sysadmin_use_case()
+    comment Constants.german_sysadmin_use_case()
   end
 end

--- a/lib/elixir_analyzer/test_suite/guessing_game.ex
+++ b/lib/elixir_analyzer/test_suite/guessing_game.ex
@@ -4,11 +4,12 @@ defmodule ElixirAnalyzer.TestSuite.GuessingGame do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   feature "uses guards" do
     find :any
     type :essential
-    comment ElixirAnalyzer.Constants.guessing_game_use_guards()
+    comment Constants.guessing_game_use_guards()
 
     form do
       def compare(_ignore, _ignore) when _ignore do
@@ -20,7 +21,7 @@ defmodule ElixirAnalyzer.TestSuite.GuessingGame do
   feature "uses default arguments" do
     find :any
     type :essential
-    comment ElixirAnalyzer.Constants.guessing_game_use_default_argument()
+    comment Constants.guessing_game_use_default_argument()
 
     form do
       def compare(_ignore, _ignore \\ :no_guess)
@@ -42,18 +43,18 @@ defmodule ElixirAnalyzer.TestSuite.GuessingGame do
   assert_no_call "doesn't use if, only multiple clause functions" do
     type :essential
     called_fn name: :if
-    comment ElixirAnalyzer.Constants.guessing_game_use_multiple_clause_functions()
+    comment Constants.guessing_game_use_multiple_clause_functions()
   end
 
   assert_no_call "doesn't use case, only multiple clause functions" do
     type :essential
     called_fn name: :case
-    comment ElixirAnalyzer.Constants.guessing_game_use_multiple_clause_functions()
+    comment Constants.guessing_game_use_multiple_clause_functions()
   end
 
   assert_no_call "doesn't use cond, only multiple clause functions" do
     type :essential
     called_fn name: :cond
-    comment ElixirAnalyzer.Constants.guessing_game_use_multiple_clause_functions()
+    comment Constants.guessing_game_use_multiple_clause_functions()
   end
 end

--- a/lib/elixir_analyzer/test_suite/high_score.ex
+++ b/lib/elixir_analyzer/test_suite/high_score.ex
@@ -4,11 +4,12 @@ defmodule ElixirAnalyzer.TestSuite.HighScore do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   feature "uses the module attribute in add_player function head" do
     find :any
     type :actionable
-    comment ElixirAnalyzer.Constants.high_score_use_default_argument_with_module_attribute()
+    comment Constants.high_score_use_default_argument_with_module_attribute()
 
     form do
       def add_player(_ignore, _ignore, _ignore \\ @_ignore) do
@@ -20,7 +21,7 @@ defmodule ElixirAnalyzer.TestSuite.HighScore do
   feature "uses a module attribute to define the initial score" do
     find :any
     type :essential
-    comment ElixirAnalyzer.Constants.high_score_use_module_attribute()
+    comment Constants.high_score_use_module_attribute()
 
     form do
       @_shallow_ignore 0
@@ -29,7 +30,7 @@ defmodule ElixirAnalyzer.TestSuite.HighScore do
 
   assert_call "uses the module attribute in reset_score" do
     type :essential
-    comment ElixirAnalyzer.Constants.high_score_use_module_attribute()
+    comment Constants.high_score_use_module_attribute()
     calling_fn module: HighScore, name: :reset_score
     called_fn name: :@
     suppress_if "uses add_player in reset_score", :pass
@@ -37,7 +38,7 @@ defmodule ElixirAnalyzer.TestSuite.HighScore do
 
   assert_call "uses add_player in reset_score" do
     type :essential
-    comment ElixirAnalyzer.Constants.high_score_use_module_attribute()
+    comment Constants.high_score_use_module_attribute()
     calling_fn module: HighScore, name: :reset_score
     called_fn name: :add_player
     suppress_if "uses the module attribute in reset_score", :pass
@@ -45,7 +46,7 @@ defmodule ElixirAnalyzer.TestSuite.HighScore do
 
   assert_call "uses Map.update/4 in update_score" do
     type :actionable
-    comment ElixirAnalyzer.Constants.high_score_use_map_update()
+    comment Constants.high_score_use_map_update()
     calling_fn module: HighScore, name: :update_score
     called_fn module: Map, name: :update
   end

--- a/lib/elixir_analyzer/test_suite/language_list.ex
+++ b/lib/elixir_analyzer/test_suite/language_list.ex
@@ -4,10 +4,11 @@ defmodule ElixirAnalyzer.TestSuite.LanguageList do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_no_call "does not call any Enum functions" do
     type :essential
     called_fn module: Enum, name: :_
-    comment ElixirAnalyzer.Constants.language_list_do_not_use_enum()
+    comment Constants.language_list_do_not_use_enum()
   end
 end

--- a/lib/elixir_analyzer/test_suite/lasagna.ex
+++ b/lib/elixir_analyzer/test_suite/lasagna.ex
@@ -4,18 +4,19 @@ defmodule ElixirAnalyzer.TestSuite.Lasagna do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_call "remaining minutes in oven are calculated based on expected minutes in oven" do
     type :actionable
     calling_fn module: Lasagna, name: :remaining_minutes_in_oven
     called_fn name: :expected_minutes_in_oven
-    comment ElixirAnalyzer.Constants.lasagna_function_reuse()
+    comment Constants.lasagna_function_reuse()
   end
 
   assert_call "total time in minutes is calculated based on preparation time in minutes" do
     type :actionable
     calling_fn module: Lasagna, name: :total_time_in_minutes
     called_fn name: :preparation_time_in_minutes
-    comment ElixirAnalyzer.Constants.lasagna_function_reuse()
+    comment Constants.lasagna_function_reuse()
   end
 end

--- a/lib/elixir_analyzer/test_suite/leap.ex
+++ b/lib/elixir_analyzer/test_suite/leap.ex
@@ -4,10 +4,11 @@ defmodule ElixirAnalyzer.TestSuite.Leap do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_no_call "does not call any functions from :calendar Erlang module" do
     type :essential
     called_fn module: :calendar, name: :_
-    comment ElixirAnalyzer.Constants.leap_erlang_calendar()
+    comment Constants.leap_erlang_calendar()
   end
 end

--- a/lib/elixir_analyzer/test_suite/list_ops.ex
+++ b/lib/elixir_analyzer/test_suite/list_ops.ex
@@ -4,64 +4,65 @@ defmodule ElixirAnalyzer.TestSuite.ListOps do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_no_call "do not call List module" do
     type :essential
     called_fn module: List, name: :_
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not call Enum module" do
     type :essential
     called_fn module: Enum, name: :_
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not call Stream module" do
     type :essential
     called_fn module: Stream, name: :_
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not use ++" do
     type :essential
     called_fn name: :++
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not use --" do
     type :essential
     called_fn name: :--
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not use hd" do
     type :essential
     called_fn name: :hd
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not use tl" do
     type :essential
     called_fn name: :tl
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not use in" do
     type :essential
     called_fn name: :in
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not use for" do
     type :essential
     called_fn name: :for
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 
   assert_no_call "do not use Kernel.length" do
     type :essential
     called_fn module: Kernel, name: :length
-    comment ElixirAnalyzer.Constants.list_ops_do_not_use_list_functions()
+    comment Constants.list_ops_do_not_use_list_functions()
   end
 end

--- a/lib/elixir_analyzer/test_suite/log_level.ex
+++ b/lib/elixir_analyzer/test_suite/log_level.ex
@@ -4,17 +4,18 @@ defmodule ElixirAnalyzer.TestSuite.LogLevel do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_call "to_label uses cond/1" do
     type :essential
-    comment ElixirAnalyzer.Constants.log_level_use_cond()
+    comment Constants.log_level_use_cond()
     calling_fn module: LogLevel, name: :to_label
     called_fn name: :cond
   end
 
   assert_call "alert_recipient uses cond/1" do
     type :essential
-    comment ElixirAnalyzer.Constants.log_level_use_cond()
+    comment Constants.log_level_use_cond()
     calling_fn module: LogLevel, name: :alert_recipient
     called_fn name: :cond
   end

--- a/lib/elixir_analyzer/test_suite/newsletter.ex
+++ b/lib/elixir_analyzer/test_suite/newsletter.ex
@@ -70,28 +70,28 @@ defmodule ElixirAnalyzer.TestSuite.Newsletter do
 
   assert_call "send_newsletter/3 calls open_log/1" do
     type :actionable
-    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_reuses_functions()
+    comment Constants.newsletter_send_newsletter_reuses_functions()
     called_fn name: :open_log
     calling_fn module: Newsletter, name: :send_newsletter
   end
 
   assert_call "send_newsletter/3 calls close_log/1" do
     type :actionable
-    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_reuses_functions()
+    comment Constants.newsletter_send_newsletter_reuses_functions()
     called_fn name: :close_log
     calling_fn module: Newsletter, name: :send_newsletter
   end
 
   assert_call "send_newsletter/3 calls read_emails/1" do
     type :actionable
-    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_reuses_functions()
+    comment Constants.newsletter_send_newsletter_reuses_functions()
     called_fn name: :read_emails
     calling_fn module: Newsletter, name: :send_newsletter
   end
 
   assert_call "send_newsletter/3 calls log_sent_email/2" do
     type :actionable
-    comment ElixirAnalyzer.Constants.newsletter_send_newsletter_reuses_functions()
+    comment Constants.newsletter_send_newsletter_reuses_functions()
     called_fn name: :log_sent_email
     calling_fn module: Newsletter, name: :send_newsletter
   end

--- a/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
+++ b/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
@@ -35,28 +35,28 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheet do
     type :actionable
     called_fn name: :welcome
     calling_fn module: RPG.CharacterSheet, name: :run
-    comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
+    comment Constants.rpg_character_sheet_run_uses_other_functions()
   end
 
   assert_call "run uses ask_name" do
     type :actionable
     called_fn name: :ask_name
     calling_fn module: RPG.CharacterSheet, name: :run
-    comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
+    comment Constants.rpg_character_sheet_run_uses_other_functions()
   end
 
   assert_call "run uses ask_class" do
     type :actionable
     called_fn name: :ask_class
     calling_fn module: RPG.CharacterSheet, name: :run
-    comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
+    comment Constants.rpg_character_sheet_run_uses_other_functions()
   end
 
   assert_call "run uses ask_level" do
     type :actionable
     called_fn name: :ask_level
     calling_fn module: RPG.CharacterSheet, name: :run
-    comment ElixirAnalyzer.Constants.rpg_character_sheet_run_uses_other_functions()
+    comment Constants.rpg_character_sheet_run_uses_other_functions()
   end
 
   feature "run ends with IO.inspect" do

--- a/lib/elixir_analyzer/test_suite/rpn_calculator_inspection.ex
+++ b/lib/elixir_analyzer/test_suite/rpn_calculator_inspection.ex
@@ -4,24 +4,25 @@ defmodule ElixirAnalyzer.TestSuite.RpnCalculatorInspection do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_no_call "does not call Process.link" do
     type :essential
     called_fn module: Process, name: :link
-    comment ElixirAnalyzer.Constants.rpn_calculator_inspection_use_start_link()
+    comment Constants.rpn_calculator_inspection_use_start_link()
   end
 
   assert_call "calls Task.start_link" do
     type :essential
     called_fn module: Task, name: :start_link
-    comment ElixirAnalyzer.Constants.rpn_calculator_inspection_use_start_link()
+    comment Constants.rpn_calculator_inspection_use_start_link()
     suppress_if "calls spawn_link", :pass
   end
 
   assert_call "calls spawn_link" do
     type :essential
     called_fn name: :spawn_link
-    comment ElixirAnalyzer.Constants.rpn_calculator_inspection_use_start_link()
+    comment Constants.rpn_calculator_inspection_use_start_link()
     suppress_if "calls Task.start_link", :pass
   end
 end

--- a/lib/elixir_analyzer/test_suite/square_root.ex
+++ b/lib/elixir_analyzer/test_suite/square_root.ex
@@ -4,22 +4,23 @@ defmodule ElixirAnalyzer.TestSuite.SquareRoot do
   """
 
   use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
 
   assert_no_call "does not call :math.sqrt" do
     type :essential
     called_fn module: :math, name: :sqrt
-    comment ElixirAnalyzer.Constants.square_root_do_not_use_built_in_sqrt()
+    comment Constants.square_root_do_not_use_built_in_sqrt()
   end
 
   assert_no_call "does not call :math.pow" do
     type :essential
     called_fn module: :math, name: :pow
-    comment ElixirAnalyzer.Constants.square_root_do_not_use_built_in_sqrt()
+    comment Constants.square_root_do_not_use_built_in_sqrt()
   end
 
   assert_no_call "does not call Float.pow" do
     type :essential
     called_fn module: Float, name: :pow
-    comment ElixirAnalyzer.Constants.square_root_do_not_use_built_in_sqrt()
+    comment Constants.square_root_do_not_use_built_in_sqrt()
   end
 end

--- a/lib/elixir_analyzer/test_suite/take_a_number.ex
+++ b/lib/elixir_analyzer/test_suite/take_a_number.ex
@@ -24,12 +24,12 @@ defmodule ElixirAnalyzer.TestSuite.TakeANumber do
   assert_no_call "doesn't call any Agent functions" do
     type :essential
     called_fn module: Agent, name: :_
-    comment ElixirAnalyzer.Constants.take_a_number_do_not_use_abstractions()
+    comment Constants.take_a_number_do_not_use_abstractions()
   end
 
   assert_no_call "doesn't call any GenServer functions" do
     type :essential
     called_fn module: GenServer, name: :_
-    comment ElixirAnalyzer.Constants.take_a_number_do_not_use_abstractions()
+    comment Constants.take_a_number_do_not_use_abstractions()
   end
 end

--- a/test/support/analyzer_verification/suppress_if.ex
+++ b/test/support/analyzer_verification/suppress_if.ex
@@ -18,10 +18,7 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.SuppressIf do
 
   assert_no_call "assert 1: no foo() unless common check was found" do
     comment "assert 1: foo() was called"
-    # This should work:
-    # suppress_if Constants.solution_debug_functions(), :fail
-    # but in assert_call, it gets treated as an AST, so the final string is required 
-    suppress_if "elixir.solution.debug_functions", :fail
+    suppress_if Constants.solution_debug_functions(), :fail
     called_fn name: :foo
   end
 


### PR DESCRIPTION
Fixes #142.

This one took me a while, when I finally got it, I couldn't help myself and I aliased `Constants` everywhere.

The issue was that we were escaping the map containing all the `assert_call` data, so everything inside was escaped. Instead, I mimicked the approach from `feature`, changed the map into a keyword list and unquoted that. The keyword list is a proper AST it seems so it worked fine (the map was not a proper AST, so I couldn't unquote it directly). 

It might be easier to review both commits separately.