### PR TITLE
Add common check for prepending items to lists

### DIFF
--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -26,6 +26,7 @@ defmodule ElixirAnalyzer.Constants do
     solution_debug_functions: "elixir.solution.debug_functions",
     solution_last_line_assignment: "elixir.solution.last_line_assignment",
     solution_compiler_warnings: "elixir.solution.compiler_warnings",
+    solution_list_prepend_head: "elixir.solution.list_prepend_head",
 
     # Concept exercises
 

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -19,6 +19,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
     quote do
       use ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions
       use ElixirAnalyzer.ExerciseTest.CommonChecks.LastLineAssignment
+      use ElixirAnalyzer.ExerciseTest.CommonChecks.ListPrependHead
       use ElixirAnalyzer.ExerciseTest.CommonChecks.UncommonErrors
     end
   end

--- a/lib/elixir_analyzer/exercise_test/common_checks/list_prepend_head.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/list_prepend_head.ex
@@ -1,0 +1,22 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ListPrependHead do
+  @moduledoc """
+  This is an exercise analyzer extension module used for common tests looking for
+  usage of `[h] ++ t` instead of `[h | t]` to prepend an item to a list
+  """
+
+  alias ElixirAnalyzer.Constants
+
+  defmacro __using__(_opts) do
+    quote do
+      feature Constants.solution_list_prepend_head() do
+        type :informative
+        comment Constants.solution_list_prepend_head()
+        find :none
+
+        form do
+          [_ignore] ++ _ignore
+        end
+      end
+    end
+  end
+end

--- a/test/elixir_analyzer/exercise_test/common_checks/list_prepend_head_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/list_prepend_head_test.exs
@@ -1,0 +1,36 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.ListPrependHead do
+  use ElixirAnalyzer.ExerciseTest
+end
+
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ListPrependHeadTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.Support.AnalyzerVerification.ListPrependHead
+
+  alias ElixirAnalyzer.Constants
+
+  test_exercise_analysis "Solutions using [h | t] to prepend to list",
+    comments: [] do
+    [
+      defmodule MyModule do
+        def prepend_ok(list) do
+          [:ok | list]
+        end
+
+        def concat_lists() do
+          [1, 2, 3] ++ [4, 5, 6]
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "Solutions using [h] ++ t to prepend to list",
+    comments: [Constants.solution_list_prepend_head()] do
+    [
+      defmodule MyModule do
+        def prepend_ok(list) do
+          [:ok] ++ list
+        end
+      end
+    ]
+  end
+end

--- a/test/elixir_analyzer/exercise_test/common_checks/list_prepend_head_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/list_prepend_head_test.exs
@@ -15,9 +15,15 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ListPrependHeadTest do
         def prepend_ok(list) do
           [:ok | list]
         end
-
-        def concat_lists() do
+      end,
+      defmodule MyModule do
+        def concat_equal_lists() do
           [1, 2, 3] ++ [4, 5, 6]
+        end
+      end,
+      defmodule MyModule do
+        def append_element() do
+          [1, 2, 3, 4, 5] ++ [6]
         end
       end
     ]
@@ -28,7 +34,28 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ListPrependHeadTest do
     [
       defmodule MyModule do
         def prepend_ok(list) do
-          [:ok] ++ list
+          [:ok] ++ [:foo]
+        end
+      end,
+      defmodule MyModule do
+        def foo_list(), do: [:foo, :bar, :baz]
+
+        def prepend_ok(list) do
+          [:ok] ++ foo_list()
+        end
+      end,
+      defmodule MyModule do
+        def foo_list(), do: [:foo, :bar, :baz]
+
+        def prepend_ok(list) do
+          foo_list() |> (&([:ok] ++ &1))
+        end
+      end,
+      defmodule MyModule do
+        def foo_list(), do: [:foo, :bar, :baz]
+
+        def prepend_ok(list) do
+          :ok |> (&([&1] ++ foo_list()))
         end
       end
     ]

--- a/test/elixir_analyzer/test_suite/accumulate_test.exs
+++ b/test/elixir_analyzer/test_suite/accumulate_test.exs
@@ -8,7 +8,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AccumulateTest do
       def accumulate([], _), do: []
 
       def accumulate([head | tail], fun) do
-        [fun.(head)] ++ accumulate(tail, fun)
+        [fun.(head) | accumulate(tail, fun)]
       end
     end
   end


### PR DESCRIPTION
Assert that `[h | t]` is used instead of `[h] ++ t`. Also replace `[h] ++ t` syntax in Accumulate test :)

Depends on https://github.com/exercism/website-copy/pull/2092. Closes #170.