### PR TITLE
Add a common check for boolean function naming patterns

### DIFF
--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -26,6 +26,7 @@ defmodule ElixirAnalyzer.Constants do
     solution_debug_functions: "elixir.solution.debug_functions",
     solution_last_line_assignment: "elixir.solution.last_line_assignment",
     solution_compiler_warnings: "elixir.solution.compiler_warnings",
+    solution_boolean_functions: "elixir.solution.boolean_functions",
 
     # Concept exercises
 

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -9,6 +9,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
     ModuleAttributeNames,
     ModulePascalCase,
     CompilerWarnings,
+    BooleanFunctions,
     Indentation
   }
 
@@ -31,6 +32,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
       ModuleAttributeNames.run(code_ast),
       ModulePascalCase.run(code_ast),
       CompilerWarnings.run(code_ast),
+      BooleanFunctions.run(code_ast),
       Indentation.run(code_ast, code_as_string)
     ]
     |> List.flatten()

--- a/lib/elixir_analyzer/exercise_test/common_checks/boolean_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/boolean_functions.ex
@@ -1,0 +1,86 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.BooleanFunctions do
+  @moduledoc """
+  Reports the first boolean function with a name that's not appropriate.
+
+  Doesn't report more if there are more.
+  A single comment should be enough for the student to know what to fix.
+
+  Common check to be run on every single solution.
+  """
+
+  alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.Comment
+
+  @spec run(Macro.t()) :: [{:pass | :fail | :skip, %Comment{}}]
+  def run(ast) do
+    {_, %{function_names: function_names}} =
+      Macro.prewalk(ast, %{function_names: []}, &traverse/2)
+
+    case List.last(function_names) do
+      nil ->
+        []
+
+      {def_type, name} ->
+        {wrong_def, correct_def} = render_names(def_type, name)
+
+        [
+          {:fail,
+           %Comment{
+             type: :actionable,
+             name: Constants.solution_boolean_functions(),
+             comment: Constants.solution_boolean_functions(),
+             params: %{
+               expected: correct_def,
+               actual: wrong_def
+             }
+           }}
+        ]
+    end
+  end
+
+  @def_ops [:def, :defp, :defmacro, :defmacrop, :defguard, :defguardp]
+  defp traverse({op, _meta, [{name, _meta2, _parameters} | _]} = ast, acc) when op in @def_ops do
+    name = to_string(name)
+
+    if correct_name?(op, name) do
+      {ast, acc}
+    else
+      {ast, Map.update!(acc, :function_names, &[{op, name} | &1])}
+    end
+  end
+
+  defp traverse(ast, acc) do
+    {ast, acc}
+  end
+
+  defp correct_name?(type, name) do
+    starts_with_is = String.starts_with?(name, "is_")
+    end_with_? = String.ends_with?(name, "?")
+
+    cond do
+      starts_with_is and end_with_? -> false
+      starts_with_is and type in [:def, :defp] -> false
+      end_with_? and type in [:defguard, :defguardp] -> false
+      true -> true
+    end
+  end
+
+  defp render_names(type, name) do
+    starts_with_is = String.starts_with?(name, "is_")
+    end_with_? = String.ends_with?(name, "?")
+
+    name_without_is = String.replace_leading(name, "is_", "")
+    name_without_? = String.replace_trailing(name, "?", "")
+
+    correct_name =
+      cond do
+        type in [:def, :defp] and starts_with_is and end_with_? -> name_without_is
+        type in [:def, :defp] -> name_without_is <> "?"
+        type in [:defguard, :defguardp] and starts_with_is and end_with_? -> name_without_?
+        type in [:defguard, :defguardp] -> "is_" <> name_without_?
+        true -> "#{name_without_?} or #{type} #{name_without_is}"
+      end
+
+    {"#{type} #{name}", "#{type} #{correct_name}"}
+  end
+end

--- a/lib/elixir_analyzer/exercise_test/common_checks/boolean_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/boolean_functions.ex
@@ -66,17 +66,16 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.BooleanFunctions do
   end
 
   defp render_names(type, name) do
-    starts_with_is = String.starts_with?(name, "is_")
-    end_with_? = String.ends_with?(name, "?")
+    is_encloded_? = String.starts_with?(name, "is_") and String.ends_with?(name, "?")
 
     name_without_is = String.replace_leading(name, "is_", "")
     name_without_? = String.replace_trailing(name, "?", "")
 
     correct_name =
       cond do
-        type in [:def, :defp] and starts_with_is and end_with_? -> name_without_is
+        type in [:def, :defp] and is_encloded_? -> name_without_is
         type in [:def, :defp] -> name_without_is <> "?"
-        type in [:defguard, :defguardp] and starts_with_is and end_with_? -> name_without_?
+        type in [:defguard, :defguardp] and is_encloded_? -> name_without_?
         type in [:defguard, :defguardp] -> "is_" <> name_without_?
         true -> "#{name_without_?} or #{type} #{name_without_is}"
       end

--- a/test/elixir_analyzer/exercise_test/common_checks/boolean_functions_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/boolean_functions_test.exs
@@ -1,0 +1,172 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.BooleanFunctionsTest do
+  use ExUnit.Case
+  alias ElixirAnalyzer.Comment
+  alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.ExerciseTest.CommonChecks.BooleanFunctions
+
+  test "returns empty list if all names are correct" do
+    code =
+      quote do
+        defmodule User do
+          def active?(user), do: user.active
+          defp registered?(user), do: true
+          defguard is_user when true
+          defguardp is_registered when true
+          defmacro is_user(user), do: true
+          defmacrop is_active(user), do: true
+          defmacro admin?(user), do: user.admin
+          defmacrop german?(user), do: user.country == "Germany"
+        end
+      end
+
+    assert BooleanFunctions.run(code) == []
+  end
+
+  test "variables don't trigger comments" do
+    code =
+      quote do
+        defmodule User do
+          def register(user) do
+            active? = true
+            is_user = true
+            is_active_user? = false
+          end
+        end
+      end
+
+    assert BooleanFunctions.run(code) == []
+  end
+
+  def assert_result(code, expected, actual) do
+    assert BooleanFunctions.run(code) == [
+             {:fail,
+              %Comment{
+                type: :actionable,
+                comment: Constants.solution_boolean_functions(),
+                name: Constants.solution_boolean_functions(),
+                params: %{
+                  expected: expected,
+                  actual: actual
+                }
+              }}
+           ]
+  end
+
+  test "returns an actionable comment with params" do
+    code =
+      quote do
+        defmodule User do
+          def is_active_user?(user), do: user.active
+        end
+      end
+
+    assert_result(code, "def active_user?", "def is_active_user?")
+  end
+
+  test "is_active_user? also works for defp, defmacro, defmacrop, defguard, and defguardp" do
+    code =
+      quote do
+        defmodule User do
+          defp is_active_user?(user), do: true
+        end
+      end
+
+    assert_result(code, "defp active_user?", "defp is_active_user?")
+
+    code =
+      quote do
+        defmodule User do
+          defmacro is_active_user?(user), do: true
+        end
+      end
+
+    assert_result(
+      code,
+      "defmacro is_active_user or defmacro active_user?",
+      "defmacro is_active_user?"
+    )
+
+    code =
+      quote do
+        defmodule User do
+          defmacrop is_active_user?(user), do: true
+        end
+      end
+
+    assert_result(
+      code,
+      "defmacrop is_active_user or defmacrop active_user?",
+      "defmacrop is_active_user?"
+    )
+
+    code =
+      quote do
+        defmodule User do
+          defguard(is_active_user?(user), do: true)
+        end
+      end
+
+    assert_result(code, "defguard is_active_user", "defguard is_active_user?")
+
+    code =
+      quote do
+        defmodule User do
+          defguardp(is_active_user?(user), do: true)
+        end
+      end
+
+    assert_result(code, "defguardp is_active_user", "defguardp is_active_user?")
+  end
+
+  test "is_active_user get comment for def, defp" do
+    code =
+      quote do
+        defmodule User do
+          def is_active_user(user), do: true
+        end
+      end
+
+    assert_result(code, "def active_user?", "def is_active_user")
+
+    code =
+      quote do
+        defmodule User do
+          defp is_active_user(user), do: true
+        end
+      end
+
+    assert_result(code, "defp active_user?", "defp is_active_user")
+  end
+
+  test "active_user? get comment for defguard, defguardp" do
+    code =
+      quote do
+        defmodule User do
+          defguard(active_user?(user), do: true)
+        end
+      end
+
+    assert_result(code, "defguard is_active_user", "defguard active_user?")
+
+    code =
+      quote do
+        defmodule User do
+          defguardp(active_user?(user), do: true)
+        end
+      end
+
+    assert_result(code, "defguardp is_active_user", "defguardp active_user?")
+  end
+
+  test "only reports the first wrong name" do
+    code =
+      quote do
+        defmodule User do
+          def is_active_user?(user), do: true
+          defp is_active_user?(user), do: true
+        end
+      end
+
+    assert_result(code, "def active_user?", "def is_active_user?")
+  end
+end


### PR DESCRIPTION
Closes #168.

This one is faulty straightforward. 