### PR TITLE
[chore] Refactor common supported type code

### DIFF
--- a/lib/elixir_analyzer/comment.ex
+++ b/lib/elixir_analyzer/comment.ex
@@ -14,4 +14,16 @@ defmodule ElixirAnalyzer.Comment do
           suppress_if: false | {String.t(), :pass | :fail},
           params: map()
         }
+
+  @supported_types ~w(essential actionable informative celebratory)a
+
+  @spec supported_type?(atom()) :: boolean()
+  def supported_type?(type) do
+    type in @supported_types
+  end
+
+  @spec supported_types() :: list(atom())
+  def supported_types do
+    @supported_types
+  end
 end

--- a/lib/elixir_analyzer/exercise_test/assert_call.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call.ex
@@ -1,6 +1,8 @@
 defmodule ElixirAnalyzer.ExerciseTest.AssertCall do
   @moduledoc false
 
+  alias ElixirAnalyzer.Comment
+
   @type function_signature() :: {list(atom()), atom()} | {nil, atom()}
 
   @doc false
@@ -90,12 +92,11 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall do
     {node, Map.put(test_data, :comment, comment)}
   end
 
-  @supported_types ~w(essential actionable informative celebratory)a
   defp do_walk_assert_call_block({:type, _, [type]} = node, test_data) do
-    if type not in @supported_types do
+    if not Comment.supported_type?(type) do
       raise """
       Unsupported type `#{type}`.
-      The macro `assert_call` supports the following types: #{Enum.join(@supported_types, ", ")}.
+      The macro `assert_call` supports the following types: #{Enum.join(Comment.supported_types(), ", ")}.
       """
     end
 

--- a/lib/elixir_analyzer/exercise_test/check_source.ex
+++ b/lib/elixir_analyzer/exercise_test/check_source.ex
@@ -3,6 +3,8 @@ defmodule ElixirAnalyzer.ExerciseTest.CheckSource do
   Defines a `check_source` macro that allows checking the source code
   """
 
+  alias ElixirAnalyzer.Comment
+
   @doc false
   defmacro __using__(_opts) do
     quote do
@@ -73,12 +75,11 @@ defmodule ElixirAnalyzer.ExerciseTest.CheckSource do
     {node, Map.put(test_data, :comment, comment)}
   end
 
-  @supported_types ~w(essential actionable informative celebratory)a
   defp do_walk_check_source_block({:type, _, [type]} = node, test_data) do
-    if type not in @supported_types do
+    if not Comment.supported_type?(type) do
       raise """
       Unsupported type `#{type}`.
-      The macro `check_source` supports the following types: #{Enum.join(@supported_types, ", ")}.
+      The macro `check_source` supports the following types: #{Enum.join(Comment.supported_types(), ", ")}.
       """
     end
 

--- a/lib/elixir_analyzer/exercise_test/feature.ex
+++ b/lib/elixir_analyzer/exercise_test/feature.ex
@@ -4,6 +4,7 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature do
   whose AST matches part of the AST of the solution.
   """
 
+  alias ElixirAnalyzer.Comment
   alias ElixirAnalyzer.ExerciseTest.Feature.FeatureError
 
   @doc false
@@ -84,12 +85,11 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature do
     :ok
   end
 
-  @supported_types ~w(essential actionable informative celebratory)a
   defp gather_feature_data({:type, _, [type]} = node, acc) do
-    if type not in @supported_types do
+    if not Comment.supported_type?(type) do
       raise """
       Unsupported type `#{type}`.
-      The macro `feature` supports the following types: #{Enum.join(@supported_types, ", ")}.
+      The macro `feature` supports the following types: #{Enum.join(Comment.supported_types(), ", ")}.
       """
     end
 

--- a/test/elixir_analyzer/comment_test.exs
+++ b/test/elixir_analyzer/comment_test.exs
@@ -1,0 +1,25 @@
+defmodule ElixirAnalyzer.CommentsTest do
+  use ExUnit.Case
+
+  alias ElixirAnalyzer.Comment
+
+  @types ~w(essential actionable informative celebratory)a
+
+  describe "supported_type?/1" do
+    for type <- @types do
+      test "#{type} passes" do
+        assert Comment.supported_type?(unquote(type))
+      end
+    end
+
+    test "other atoms are not supported" do
+      refute Comment.supported_type?(:super_actionable)
+    end
+  end
+
+  describe "supported_types/0" do
+    test "lists all types" do
+      assert Comment.supported_types() == @types
+    end
+  end
+end


### PR DESCRIPTION
Small refactor to co-locate Comment common type checks.

P.S. Thanks @jiegillet for letting me do this small chore, let me crawl through the code a bit as I have been less connected to it lately.  I appreciate.