### PR TITLE
Ensure unit tests on CI always run with the latest commit from main of the exercism/elixir git submodule

### DIFF
--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -10,9 +10,19 @@ jobs:
       image: hexpm/elixir:1.12.1-erlang-24.0.1-ubuntu-focal-20210325
 
     steps:
-      - uses: actions/checkout@v1
+      - name: Install git
+        run: |
+          apt-get update
+          apt-get install -y git
+
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
         with:
-          submodules: true
+          submodules: recursive
+
+      - name: Update submodules
+        run: |
+          git submodule update --recursive --remote
 
       - name: Install Dependencies
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "elixir"]
-	path = elixir
-	url = https://github.com/exercism/elixir.git
+    path = elixir
+    branch = main
+    url = https://github.com/exercism/elixir.git


### PR DESCRIPTION
Closes #209.

I tried many things and could not understand why git was failing all the time, it turns out that git wasn't installed at all in the `hexpm/elixir` container. What was confusing is that `actions/checkout ` still worked, that was because there is a backup REST API in case git isn't installed, but in that case the submodules are not handled.

I ended up installing git (which adds 12 seconds to the test CI), checking out the repo and submodule, and then manually updating the submodule. This update is only done in the CI and the update is not committed. I also had to specify the branch to update to in `.gitmodules`.