### PR TITLE
`assert_call` recognizes captured function for direct and indirect calls

### DIFF
--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -405,11 +405,20 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
       when not is_nil(name) and is_list(args) do
     called =
       case function do
-        {:., _, [{:__MODULE__, _, _}, fn_name]} -> {module, fn_name}
-        {:., _, [{:__aliases__, _, fn_module}, fn_name]} -> {fn_module, fn_name}
-        {:|>, _, [_arg, {fn_name, _, atom}]} when is_atom(atom) -> {module, fn_name}
-        {:/, _, [{fn_name, _, atom}, _arity]} when is_atom(atom) -> {module, fn_name}
-        {fn_name, _, _} -> {module, fn_name}
+        {:., _, [{:__MODULE__, _, _}, fn_name]} ->
+          {module, fn_name}
+
+        {:., _, [{:__aliases__, _, fn_module}, fn_name]} ->
+          {fn_module, fn_name}
+
+        {:|>, _, [_arg, {fn_name, _, atom}]} when is_atom(atom) ->
+          {module, fn_name}
+
+        {:/, _, [{fn_name, _, atom}, arity]} when is_atom(atom) and is_integer(arity) ->
+          {module, fn_name}
+
+        {fn_name, _, _} ->
+          {module, fn_name}
       end
 
     %{acc | function_call_tree: Map.update(tree, {module, name}, [called], &[called | &1])}

--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -166,14 +166,17 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
   end
 
   # No module path in search
-  def matching_function_call?({name, _, args}, {nil, name}, _modules) when is_list(args) do
-    true
-  end
-
-  # Matching function call without parentheses in a pipe
-  def matching_function_call?({:|>, _, [_arg, {name, _, atom}]}, {nil, name}, _modules)
-      when is_atom(atom) do
-    true
+  def matching_function_call?({_, _, args} = function, {nil, name}, _modules)
+      when is_list(args) do
+    case function do
+      # function call without parentheses in a pipe
+      {:|>, _, [_arg, {^name, _, atom}]} when is_atom(atom) -> true
+      # function call with captured notation
+      {:/, _, [{^name, _, atom}, arity]} when is_atom(atom) and is_integer(arity) -> true
+      # with parentheses
+      {^name, _, _args} -> true
+      _ -> false
+    end
   end
 
   # Module path in AST
@@ -405,6 +408,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
         {:., _, [{:__MODULE__, _, _}, fn_name]} -> {module, fn_name}
         {:., _, [{:__aliases__, _, fn_module}, fn_name]} -> {fn_module, fn_name}
         {:|>, _, [_arg, {fn_name, _, atom}]} when is_atom(atom) -> {module, fn_name}
+        {:/, _, [{fn_name, _, atom}, _arity]} when is_atom(atom) -> {module, fn_name}
         {fn_name, _, _} -> {module, fn_name}
       end
 

--- a/test/elixir_analyzer/exercise_test/assert_call/indirect_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call/indirect_call_test.exs
@@ -139,7 +139,33 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.IndirectCallTest do
           :math.pi |> final_function
         end
       end
-      """
+      """,
+      # call helper function via captured function
+      defmodule AssertCallVerification do
+        def main_function do
+          :ok
+          |> then(&helper/0)
+          |> do_something
+        end
+
+        def helper do
+          Elixir.Mix.Utils.read_path()
+          :math.pi() |> final_function
+        end
+      end,
+      # helper function and target function in captured notation
+      defmodule AssertCallVerification do
+        def main_function do
+          :ok
+          |> then(&helper/0)
+          |> do_something
+        end
+
+        def helper do
+          Elixir.Mix.Utils.read_path()
+          :math.pi() |> then(&final_function/1)
+        end
+      end
     ]
   end
 

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -4,23 +4,43 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
 
   test_exercise_analysis "perfect solution",
     comments: [] do
-    defmodule AssertCallVerification do
-      def function() do
-        x = List.first([1, 2, 3])
-        result = helper()
-        IO.puts(result)
+    [
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = helper()
+          IO.puts(result)
 
-        private_helper() |> IO.puts()
-      end
+          private_helper() |> IO.puts()
+        end
 
-      def helper do
-        :helped
-      end
+        def helper do
+          :helped
+        end
 
-      defp private_helper do
-        :privately_helped
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      # call helper with capture notation
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = Enum.map(result, &helper/0)
+          IO.puts(result)
+
+          private_helper() |> IO.puts()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
       end
-    end
+    ]
   end
 
   test_exercise_analysis "missing local call from anywhere in solution",
@@ -129,6 +149,27 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
       end
 
       defp private_helper do
+        :privately_helped
+      end
+    end
+  end
+
+  test_exercise_analysis "indirect call to a List function in function/0 via captured helper function",
+    comments: [] do
+    defmodule AssertCallVerification do
+      def function() do
+        result = helper()
+        IO.puts(result)
+
+        result |> Enum.map(&private_helper/1) |> IO.puts()
+      end
+
+      def helper do
+        :helped
+      end
+
+      defp private_helper(list) do
+        l = List.first(list)
         :privately_helped
       end
     end

--- a/test/elixir_analyzer/test_suite/high_school_sweetheart_test.exs
+++ b/test/elixir_analyzer/test_suite/high_school_sweetheart_test.exs
@@ -51,6 +51,42 @@ defmodule ElixirAnalyzer.TestSuite.HighSchoolSweetheartTest do
     '''
   end
 
+  test_exercise_analysis "other solution",
+    comments: [] do
+    # https://exercism.org/tracks/elixir/exercises/high-school-sweetheart/solutions/kavu
+    ~S'''
+    defmodule HighSchoolSweetheart do
+      def first_letter(name), do: name |> String.trim() |> String.first()
+      def initial(name), do: name |> first_letter |> String.upcase() |> Kernel.<>(".")
+
+      def initials(full_name),
+        do: full_name |> String.split() |> Enum.map(&initial/1) |> Enum.join(" ")
+
+      def pair(full_name1, full_name2) do
+        first_initials = initials(full_name1)
+        second_initials = initials(full_name2)
+
+        """
+             ******       ******
+           **      **   **      **
+         **         ** **         **
+        **            *            **
+        **                         **
+        **     #{first_initials}  +  #{second_initials}     **
+         **                       **
+           **                   **
+             **               **
+               **           **
+                 **       **
+                   **   **
+                     ***
+                      *
+        """
+      end
+    end
+    '''
+  end
+
   describe "function reuse" do
     test_exercise_analysis "detects lack of reuse in all cases",
       comments_include: [Constants.high_school_sweetheart_function_reuse()] do


### PR DESCRIPTION
#208 introduced a bug: since captured functions `function/1` are transformed to `{:/, _, [{:function, [], Elixir}, 2]}` they looked like a variable and were therefore not considered. We didn't have any tests for this case.

This PR fixes that, both recognizing the target function in captured notation, or indirectly via helper functions in captured notations.