### PR TITLE
Modify `check_source` to take a `%Source{}` argument instead of a string

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -131,3 +131,19 @@ feature "description" do
   end
 end
 ```
+
+## Check that a solution contains comments
+
+The `check_source` type of check can access the data in the `%Source{}` struct (submission code as string or AST, exercise slug and type, exemplar/example as string or AST, and more), which can be used for advanced checks. The function `check` must return a boolean. `check_source` is powerful but primitive, `feature` or `assert_call` should be preferred if they can be used as they have more refined features (such as imports tracking). 
+
+```elixir
+check_source "code contains comments" do
+
+  check(%Source{code_string: code_string}) do
+    code_string
+      |> String.split("\n")
+      |> Enum.any?(&String.starts_with?(&1, "#"))
+  end 
+end 
+```
+

--- a/lib/elixir_analyzer/exercise_test.ex
+++ b/lib/elixir_analyzer/exercise_test.ex
@@ -39,7 +39,7 @@ defmodule ElixirAnalyzer.ExerciseTest do
 
     # placeholders for submission code
     code_ast = quote do: code_ast
-    code_string = quote do: code_string
+    source = quote do: source
 
     # compile each feature to a test
     feature_tests = Enum.map(feature_test_data, &FeatureCompiler.compile(&1, code_ast))
@@ -48,8 +48,7 @@ defmodule ElixirAnalyzer.ExerciseTest do
     assert_call_tests = Enum.map(assert_call_data, &AssertCallCompiler.compile(&1, code_ast))
 
     # compile each check_source to a test
-    check_source_tests =
-      Enum.map(check_source_data, &CheckSourceCompiler.compile(&1, code_string))
+    check_source_tests = Enum.map(check_source_data, &CheckSourceCompiler.compile(&1, source))
 
     quote do
       @spec analyze(Submission.t(), Source.t()) :: Submission.t()
@@ -64,13 +63,7 @@ defmodule ElixirAnalyzer.ExerciseTest do
         end
       end
 
-      defp do_analyze(
-             %Submission{} = submission,
-             %Source{
-               code_string: code_string,
-               code_ast: code_ast
-             } = source
-           ) do
+      defp do_analyze(%Submission{} = submission, %Source{code_ast: code_ast} = source) do
         results =
           Enum.concat([
             unquote(feature_tests),

--- a/lib/elixir_analyzer/exercise_test/check_source/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/check_source/compiler.ex
@@ -2,8 +2,9 @@ defmodule ElixirAnalyzer.ExerciseTest.CheckSource.Compiler do
   @moduledoc false
 
   alias ElixirAnalyzer.Comment
+  alias ElixirAnalyzer.Source
 
-  def compile({check_source_data, check_function}, code_string) do
+  def compile({check_source_data, check_function}, code_source) do
     name = Keyword.fetch!(check_source_data, :description)
     comment = Keyword.fetch!(check_source_data, :comment)
     type = Keyword.get(check_source_data, :type, :informative)
@@ -18,13 +19,13 @@ defmodule ElixirAnalyzer.ExerciseTest.CheckSource.Compiler do
       })
 
     quote do
-      (fn string ->
-         if unquote(check_function).(string) do
+      (fn %Source{} = source ->
+         if unquote(check_function).(source) do
            {:pass, unquote(test_description)}
          else
            {:fail, unquote(test_description)}
          end
-       end).(unquote(code_string))
+       end).(unquote(code_source))
     end
   end
 end

--- a/lib/elixir_analyzer/test_suite/german_sysadmin.ex
+++ b/lib/elixir_analyzer/test_suite/german_sysadmin.ex
@@ -5,6 +5,7 @@ defmodule ElixirAnalyzer.TestSuite.GermanSysadmin do
 
   use ElixirAnalyzer.ExerciseTest
   alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.Source
 
   assert_no_call "doesn't convert anything to a string" do
     type :essential
@@ -40,9 +41,9 @@ defmodule ElixirAnalyzer.TestSuite.GermanSysadmin do
     type :actionable
     comment Constants.solution_no_integer_literal()
 
-    check(source) do
+    check(%Source{code_string: code_string}) do
       integers = ["?ß", "?ä", "?ö", "?ü", "?_", "?a", "?z"]
-      Enum.all?(integers, &String.contains?(source, &1))
+      Enum.all?(integers, &String.contains?(code_string, &1))
     end
   end
 end

--- a/test/support/analyzer_verification/check_source.ex
+++ b/test/support/analyzer_verification/check_source.ex
@@ -2,8 +2,9 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.CheckSource do
   @moduledoc """
   This is an exercise analyzer extension module to test the check_soucre macro
   """
-
   use ElixirAnalyzer.ExerciseTest
+
+  alias ElixirAnalyzer.Source
 
   check_source "always true" do
     type :actionable
@@ -27,10 +28,10 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.CheckSource do
     type :actionable
     comment "used integer literal from ?a to ?z"
 
-    check(source) do
+    check(%Source{code_string: code_string}) do
       integers = Enum.map(?a..?z, &to_string/1)
 
-      not Enum.any?(integers, &String.contains?(source, &1))
+      not Enum.any?(integers, &String.contains?(code_string, &1))
     end
   end
 
@@ -38,8 +39,8 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.CheckSource do
     type :actionable
     comment "didn't use multiline"
 
-    check(source) do
-      String.contains?(source, ["\"\"\"", "\'\'\'"])
+    check(%Source{code_string: code_string}) do
+      String.contains?(code_string, ["\"\"\"", "\'\'\'"])
     end
   end
 
@@ -47,8 +48,8 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.CheckSource do
     type :actionable
     comment "module is too short"
 
-    check(source) do
-      String.length(source) > 20
+    check(%Source{code_string: code_string}) do
+      String.length(code_string) > 20
     end
   end
 
@@ -56,8 +57,8 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.CheckSource do
     type :actionable
     comment "module is not formatted"
 
-    check(source) do
-      String.trim(source) == Code.format_string!(source) |> Enum.join()
+    check(%Source{code_string: code_string}) do
+      String.trim(code_string) == Code.format_string!(code_string) |> Enum.join()
     end
   end
 end

--- a/test/support/analyzer_verification/suppress_if.ex
+++ b/test/support/analyzer_verification/suppress_if.ex
@@ -4,6 +4,7 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.SuppressIf do
   """
 
   alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.Source
   use ElixirAnalyzer.ExerciseTest
 
   feature "feature 1: no foo() unless common check was found" do
@@ -25,7 +26,7 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.SuppressIf do
   check_source "check source 1: no foo() unless common check was found" do
     comment "check source 1: foo() was called"
     suppress_if Constants.solution_debug_functions(), :fail
-    check(source, do: not String.contains?(source, "foo"))
+    check(%Source{code_string: code_string}, do: not String.contains?(code_string, "foo"))
   end
 
   feature "feature 2: no bar() unless assert 1 found a foo() first" do
@@ -47,7 +48,7 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.SuppressIf do
   check_source "check source 2: no bar() unless assert 1 found a foo() first" do
     comment "check source 2: bar() was called"
     suppress_if "check source 1: no foo() unless common check was found", :fail
-    check(source, do: not String.contains?(source, "bar"))
+    check(%Source{code_string: code_string}, do: not String.contains?(code_string, "bar"))
   end
 
   feature "feature 3: no baz() unless feature 1 found a foo() first" do
@@ -69,6 +70,6 @@ defmodule ElixirAnalyzer.Support.AnalyzerVerification.SuppressIf do
   check_source "check source 3: no baz() unless feature 1 found a foo() first" do
     comment "check source 3: baz() was called"
     suppress_if "feature 1: no foo() unless common check was found", :fail
-    check(source, do: not String.contains?(source, "baz"))
+    check(%Source{code_string: code_string}, do: not String.contains?(code_string, "baz"))
   end
 end


### PR DESCRIPTION
I also added an example in the recipes. I admit I didn't muster the motivation to add a chapter about it in the guide, most likely because it wouldn't make sense without also adding a chapter about `assert_call`.