### PR TITLE
Common check: function capture instead of defining a new anonymous function

### DIFF
--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -37,6 +37,7 @@ defmodule ElixirAnalyzer.Constants do
     solution_todo_comment: "elixir.solution.todo_comment",
     solution_private_helper_functions: "elixir.solution.private_helper_functions",
     solution_unless_with_else: "elixir.solution.unless_with_else",
+    solution_use_function_capture: "elixir.solution.use_function_capture",
 
     # Concept exercises
 

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -13,6 +13,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
     ExemplarComparison,
     Indentation,
     PrivateHelperFunctions,
+    FunctionCapture,
     Comments
   }
 
@@ -48,6 +49,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
       ExemplarComparison.run(code_ast, type, exemploid_ast),
       Indentation.run(code_ast, code_string),
       PrivateHelperFunctions.run(code_ast, exemploid_ast),
+      FunctionCapture.run(code_ast),
       Comments.run(code_ast, code_string)
     ]
     |> List.flatten()

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
@@ -31,7 +31,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCapture do
     end
   end
 
-  @exceptions [:<<>>, :{}, :|]
+  @exceptions [:<<>>, :{}]
   defp traverse({:&, _, [{name, _, args}]} = node, functions) when name not in @exceptions do
     wrong_use? =
       args

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
@@ -45,6 +45,12 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCapture do
     end
   end
 
+  # fn -> foo end
+  defp traverse({:fn, _, [{:->, _, [[], {name, _, atom}]}]} = node, functions)
+       when is_atom(atom) do
+    {node, [{:fn, name, nil} | functions]}
+  end
+
   defp traverse({:fn, _, [{:->, _, [args, {name, _, args}]}]} = node, functions)
        when name not in @exceptions do
     args = Enum.map(args, fn {var, _, _} -> var end)
@@ -81,11 +87,18 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCapture do
     {wrong, correct}
   end
 
+  defp format_function({:fn, name, nil}) do
+    correct = "&#{name}/0"
+    wrong = "fn -> #{name} end"
+    {wrong, correct}
+  end
+
   defp format_function({:fn, name, args}) do
     name = format_function_name(name)
     correct = "&#{name}/#{length(args)}"
+    space = if Enum.empty?(args), do: "", else: " "
     args = Enum.join(args, ", ")
-    wrong = "fn #{args} -> #{name}(#{args}) end"
+    wrong = "fn #{args}#{space}-> #{name}(#{args}) end"
     {wrong, correct}
   end
 

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
@@ -1,0 +1,102 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCapture do
+  @moduledoc """
+  Check if anonymous functions are used where function capture can be used instead
+  """
+
+  alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.Comment
+
+  @spec run(Macro.t()) :: [{:pass | :fail | :skip, %Comment{}}]
+  def run(code_ast) do
+    {_, functions} =
+      Macro.prewalk(code_ast, [], fn ast, functions -> traverse(ast, functions) end)
+
+    case functions |> Enum.map(&format_function(&1)) |> Enum.reverse() do
+      [] ->
+        []
+
+      [{wrong_function, correct_function} | _] ->
+        [
+          {:fail,
+           %Comment{
+             type: :informative,
+             name: Constants.solution_use_function_capture(),
+             comment: Constants.solution_use_function_capture(),
+             params: %{
+               expected: correct_function,
+               actual: wrong_function
+             }
+           }}
+        ]
+    end
+  end
+
+  @exceptions [:<<>>, :{}, :|]
+  defp traverse({:&, _, [{name, _, args}]} = node, functions) when name not in @exceptions do
+    wrong_use? =
+      args
+      |> Enum.with_index(1)
+      |> Enum.all?(&match?({{:&, _, [index]}, index}, &1))
+
+    if wrong_use? and actual_function?(name) do
+      {node, [{:&, name, length(args)} | functions]}
+    else
+      {node, functions}
+    end
+  end
+
+  defp traverse({:fn, _, [{:->, _, [args, {name, _, args}]}]} = node, functions)
+       when name not in @exceptions do
+    args = Enum.map(args, fn {var, _, _} -> var end)
+
+    if actual_function?(name) do
+      {node, [{:fn, name, args} | functions]}
+    else
+      {node, functions}
+    end
+  end
+
+  defp traverse(node, functions) do
+    {node, functions}
+  end
+
+  defp actual_function?(name) when is_atom(name), do: true
+
+  defp actual_function?({:., _, [{:__aliases__, _, _module_path}, name]}) when is_atom(name) do
+    true
+  end
+
+  defp actual_function?({:., _, [module, name]}) when is_atom(module) and is_atom(name) do
+    true
+  end
+
+  # motivation for this check: fn string -> unquote(parser).(string) end
+  defp actual_function?(_), do: false
+
+  defp format_function({:&, name, arity}) do
+    name = format_function_name(name)
+    correct = "&#{name}/#{arity}"
+    args = Enum.map_join(1..arity, ", ", fn n -> "&#{n}" end)
+    wrong = "&#{name}(#{args})"
+    {wrong, correct}
+  end
+
+  defp format_function({:fn, name, args}) do
+    name = format_function_name(name)
+    correct = "&#{name}/#{length(args)}"
+    args = Enum.join(args, ", ")
+    wrong = "fn #{args} -> #{name}(#{args}) end"
+    {wrong, correct}
+  end
+
+  defp format_function_name(name) when is_atom(name), do: name
+
+  defp format_function_name({:., _, [{:__aliases__, _, module_path}, name]}) do
+    "#{Enum.map_join(module_path, ".", &to_string/1)}.#{name}"
+  end
+
+  # Erlang functions
+  defp format_function_name({:., _, [module, name]}) do
+    ":#{module}.#{name}"
+  end
+end

--- a/lib/elixir_analyzer/test_suite/top_secret.ex
+++ b/lib/elixir_analyzer/test_suite/top_secret.ex
@@ -3,8 +3,10 @@ defmodule ElixirAnalyzer.TestSuite.TopSecret do
   This is an exercise analyzer extension module for the concept exercise Top Secret
   """
 
-  use ElixirAnalyzer.ExerciseTest
   alias ElixirAnalyzer.Constants
+
+  use ElixirAnalyzer.ExerciseTest,
+    suppress_tests: [Constants.solution_use_function_capture()]
 
   assert_call "decode_secret_message/1 uses to_ast/1" do
     type :essential

--- a/lib/elixir_analyzer/test_suite/top_secret.ex
+++ b/lib/elixir_analyzer/test_suite/top_secret.ex
@@ -4,9 +4,7 @@ defmodule ElixirAnalyzer.TestSuite.TopSecret do
   """
 
   alias ElixirAnalyzer.Constants
-
-  use ElixirAnalyzer.ExerciseTest,
-    suppress_tests: [Constants.solution_use_function_capture()]
+  use ElixirAnalyzer.ExerciseTest
 
   assert_call "decode_secret_message/1 uses to_ast/1" do
     type :essential
@@ -20,15 +18,5 @@ defmodule ElixirAnalyzer.TestSuite.TopSecret do
     calling_fn module: TopSecret, name: :decode_secret_message
     called_fn module: TopSecret, name: :decode_secret_message_part
     comment Constants.top_secret_function_reuse()
-  end
-
-  feature "references decode_secret_message_part/2 by capturing it" do
-    find :any
-    type :actionable
-    comment Constants.top_secret_function_capture()
-
-    form do
-      &decode_secret_message_part/2
-    end
   end
 end

--- a/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
@@ -33,8 +33,8 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCaptureTest do
             |> Enum.reduce([], &div(&2, &1))
             |> Enum.reduce([], fn n, acc -> String.pad_leading(n, acc, "42") end)
             |> Enum.reduce([], &String.pad_leading(&1, &2, "42"))
-            |> Enum.map(fn x -> IO.inspect(x, charlists: :as_lists) end)
-            |> Enum.map(&IO.inspect(&1, charlists: :as_lists))
+            |> Enum.map(fn x -> String.split(x, ";") end)
+            |> Enum.map(&String.split(&1, ";"))
           end
 
           def exceptions(input) do

--- a/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
@@ -35,6 +35,11 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCaptureTest do
             |> Enum.reduce([], &String.pad_leading(&1, &2, "42"))
             |> Enum.map(fn x -> String.split(x, ";") end)
             |> Enum.map(&String.split(&1, ";"))
+            # behavior modified by using guards
+            |> Enum.map(fn x when is_binary(x) -> String.downcase(x) end)
+            # behavior modified by using pattern-matching
+            |> Enum.map(fn {a, b} = x -> inspect(x) end)
+            |> Enum.map(fn x = {a, b} -> inspect(x) end)
           end
 
           def exceptions(input) do

--- a/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
@@ -1,0 +1,335 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCaptureTest do
+  use ExUnit.Case
+
+  alias ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCapture
+  alias ElixirAnalyzer.Comment
+  alias ElixirAnalyzer.Constants
+
+  @comment %Comment{
+    type: :informative,
+    comment: Constants.solution_use_function_capture(),
+    name: Constants.solution_use_function_capture()
+  }
+
+  test "using valid notation for several cases" do
+    code =
+      quote do
+        defmodule Capture do
+          import Float, only: [ratio: 1, pow: 2]
+
+          def captured(input) do
+            input
+            |> Enum.map(&ratio/1)
+            |> Enum.map(&Float.round/1)
+            |> Enum.map(&:math.sin/1)
+            |> Enum.zip_with(input, &pow/2)
+            |> Enum.zip_with(input, &Float.ceil/2)
+            |> Enum.zip_with(input, &:math.atan2/2)
+          end
+
+          def legit(input) do
+            input
+            |> Enum.reduce([], fn n, acc -> div(acc, n) end)
+            |> Enum.reduce([], &div(&2, &1))
+            |> Enum.reduce([], fn n, acc -> String.pad_leading(n, acc, "42") end)
+            |> Enum.reduce([], &String.pad_leading(&1, &2, "42"))
+            |> Enum.map(fn x -> IO.inspect(x, charlists: :as_lists) end)
+            |> Enum.map(&IO.inspect(&1, charlists: :as_lists))
+          end
+
+          def exceptions(input) do
+            input
+            |> Enum.map(&<<&1>>)
+            |> Enum.map(fn x -> <<x>> end)
+            |> Enum.reduce([], fn a, b -> {a, b} end)
+            |> Enum.reduce([], &{&1, &2})
+            |> Enum.reduce([], fn a, b -> [a | b] end)
+            |> Enum.reduce([], &[&1 | &2])
+          end
+
+          # https://github.com/exercism/elixir/blob/main/exercises/practice/sgf-parsing/.meta/example.ex
+          defmacrop lazy(parser) do
+            quote do
+              fn string -> unquote(parser).(string) end
+            end
+          end
+        end
+      end
+
+    assert FunctionCapture.run(code) == []
+  end
+
+  describe "catches fn notation" do
+    test "function in scope" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, fn x -> to_string(x) end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{actual: "fn x -> to_string(x) end", expected: "&to_string/1"}
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "function with module path" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, fn x -> Integer.to_string(x) end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{actual: "fn x -> Integer.to_string(x) end", expected: "&Integer.to_string/1"}
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "function with longer module path" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, fn x -> Elixir.Integer.to_string(x) end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{
+            actual: "fn x -> Elixir.Integer.to_string(x) end",
+            expected: "&Elixir.Integer.to_string/1"
+          }
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "Erlang module" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, fn x -> :math.ceil(x) end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{actual: "fn x -> :math.ceil(x) end", expected: "&:math.ceil/1"}
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "function in scope, more variables" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.zip_with(input, input, fn x, y, z -> update_in(x, y, z) end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{actual: "fn x, y, z -> update_in(x, y, z) end", expected: "&update_in/3"}
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "function with module path, more variables" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.zip_with(input, input, fn x, y, z -> Kernel.update_in(x, y, z) end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{
+            actual: "fn x, y, z -> Kernel.update_in(x, y, z) end",
+            expected: "&Kernel.update_in/3"
+          }
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "Erlang module, more variables" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, fn a, b, c, d -> :gen_server.multi_call(a, b, c, d) end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{
+            actual: "fn a, b, c, d -> :gen_server.multi_call(a, b, c, d) end",
+            expected: "&:gen_server.multi_call/4"
+          }
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+  end
+
+  describe "catches & notation" do
+    test "function in scope" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, &to_string(&1))
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{actual: "&to_string(&1)", expected: "&to_string/1"}
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "function with module path" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, &Integer.to_string(&1))
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{actual: "&Integer.to_string(&1)", expected: "&Integer.to_string/1"}
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "function with longer module path" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, &Elixir.Integer.to_string(&1))
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{
+            actual: "&Elixir.Integer.to_string(&1)",
+            expected: "&Elixir.Integer.to_string/1"
+          }
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "Erlang module" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, &:math.ceil(&1))
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{actual: "&:math.ceil(&1)", expected: "&:math.ceil/1"}
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "function in scope, more variables" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.zip_with(input, input, &update_in(&1, &2, &3))
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{actual: "&update_in(&1, &2, &3)", expected: "&update_in/3"}
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "function with module path, more variables" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.zip_with(input, input, &Kernel.update_in(&1, &2, &3))
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{
+            actual: "&Kernel.update_in(&1, &2, &3)",
+            expected: "&Kernel.update_in/3"
+          }
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "Erlang module, more variables" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, &:gen_server.multi_call(&1, &2, &3, &4))
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{
+            actual: "&:gen_server.multi_call(&1, &2, &3, &4)",
+            expected: "&:gen_server.multi_call/4"
+          }
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+  end
+end

--- a/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
@@ -192,6 +192,48 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCaptureTest do
 
       assert FunctionCapture.run(code) == [{:fail, comment}]
     end
+
+    test "Function of arity 0, with parentheses" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, fn -> exports() end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{
+            actual: "fn -> exports() end",
+            expected: "&exports/0"
+          }
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
+
+    test "Function of arity 0, no parentheses" do
+      code =
+        quote do
+          defmodule Capture do
+            def capture(input) do
+              Enum.map(input, fn -> exports end)
+            end
+          end
+        end
+
+      comment = %{
+        @comment
+        | params: %{
+            actual: "fn -> exports end",
+            expected: "&exports/0"
+          }
+      }
+
+      assert FunctionCapture.run(code) == [{:fail, comment}]
+    end
   end
 
   describe "catches & notation" do

--- a/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
@@ -51,6 +51,10 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCaptureTest do
               fn string -> unquote(parser).(string) end
             end
           end
+
+          def nested_capture(input) do
+            Enum.map(slices, &Enum.reduce(&1, fn x, acc -> x * acc end))
+          end
         end
       end
 

--- a/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
@@ -41,10 +41,8 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCaptureTest do
             input
             |> Enum.map(&<<&1>>)
             |> Enum.map(fn x -> <<x>> end)
-            |> Enum.reduce([], fn a, b -> {a, b} end)
-            |> Enum.reduce([], &{&1, &2})
-            |> Enum.reduce([], fn a, b -> [a | b] end)
-            |> Enum.reduce([], &[&1 | &2])
+            |> Enum.reduce([], fn a, b, c -> {a, b, c} end)
+            |> Enum.reduce([], &{&1, &2, &2})
           end
 
           # https://github.com/exercism/elixir/blob/main/exercises/practice/sgf-parsing/.meta/example.ex

--- a/test/elixir_analyzer/exercise_test/common_checks_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks_test.exs
@@ -290,4 +290,68 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecksTest do
       ]
     end
   end
+
+  describe "boolean functions" do
+    test_exercise_analysis "reports function with wrong name",
+      comments: [Constants.solution_def_with_is()] do
+      [
+        defmodule MyModule do
+          def is_active_user?(user), do: user.active
+        end,
+        defmodule MyModule do
+          defp is_active_user?(user), do: user.active
+        end,
+        defmodule MyModule do
+          def is_active_user(user), do: user.active
+        end,
+        defmodule MyModule do
+          defp is_active_user(user), do: user.active
+        end
+      ]
+    end
+
+    test_exercise_analysis "reports guard with wrong name",
+      comments: [Constants.solution_defguard_with_question_mark()] do
+      [
+        defmodule MyModule do
+          defguard(is_active_user?(user), do: true)
+        end,
+        defmodule MyModule do
+          defguardp(is_active_user?(user), do: true)
+        end,
+        defmodule MyModule do
+          defguard(active_user?(user), do: true)
+        end,
+        defmodule MyModule do
+          defguardp(active_user?(user), do: true)
+        end
+      ]
+    end
+
+    test_exercise_analysis "reports macro with wrong name",
+      comments: [Constants.solution_defmacro_with_is_and_question_mark()] do
+      [
+        defmodule MyModule do
+          defmacro is_active_user?(user), do: user.active
+        end,
+        defmodule MyModule do
+          defmacrop is_active_user?(user), do: user.active
+        end
+      ]
+    end
+  end
+
+  describe "function capture" do
+    test_exercise_analysis "reports creating anonymous function rather then function capture",
+      comments: [Constants.solution_use_function_capture()] do
+      [
+        defmodule MyModule do
+          def do_nothing(list), do: Enum.map(list, fn x -> Function.identity(x) end)
+        end,
+        defmodule MyModule do
+          def do_nothing(list), do: Enum.map(list, &Function.identity(&1))
+        end
+      ]
+    end
+  end
 end

--- a/test/elixir_analyzer/test_suite/bird_count_test.exs
+++ b/test/elixir_analyzer/test_suite/bird_count_test.exs
@@ -60,10 +60,10 @@ defmodule ElixirAnalyzer.ExerciseTest.BirdCountTest do
           def today(list), do: List.first(list)
         end,
         defmodule BirdCount do
-          def total(list), do: List.foldl(list, 0, fn a, b -> a + b end)
+          def total(list), do: List.foldl(list, 0, &+/2)
         end,
         defmodule BirdCount do
-          def total(list), do: List.foldr(list, 0, fn a, b -> a + b end)
+          def total(list), do: List.foldr(list, 0, &+/2)
         end,
         defmodule BirdCount do
           import List

--- a/test/elixir_analyzer/test_suite/list_ops_test.exs
+++ b/test/elixir_analyzer/test_suite/list_ops_test.exs
@@ -52,7 +52,7 @@ defmodule ElixirAnalyzer.ExerciseTest.ListOpsTest do
       defp do_append([h | t], b), do: do_append(t, [h | b])
 
       @spec concat([[any]]) :: [any]
-      def concat(ll), do: reverse(ll) |> foldl([], &append(&1, &2))
+      def concat(ll), do: reverse(ll) |> foldl([], &append/2)
     end
   end
 

--- a/test/elixir_analyzer/test_suite/top_secret_test.exs
+++ b/test/elixir_analyzer/test_suite/top_secret_test.exs
@@ -181,7 +181,8 @@ defmodule ElixirAnalyzer.TestSuite.TopSecretTest do
 
   describe "function capture" do
     test_exercise_analysis "reports instances of creating a new function",
-      comments_include: [Constants.top_secret_function_capture()] do
+      comments_include: [Constants.top_secret_function_capture()],
+      comments_exclude: [Constants.solution_use_function_capture()] do
       [
         defmodule TopSecret do
           def decode_secret_message(string) do

--- a/test/elixir_analyzer/test_suite/top_secret_test.exs
+++ b/test/elixir_analyzer/test_suite/top_secret_test.exs
@@ -178,35 +178,4 @@ defmodule ElixirAnalyzer.TestSuite.TopSecretTest do
       ]
     end
   end
-
-  describe "function capture" do
-    test_exercise_analysis "reports instances of creating a new function",
-      comments_include: [Constants.top_secret_function_capture()],
-      comments_exclude: [Constants.solution_use_function_capture()] do
-      [
-        defmodule TopSecret do
-          def decode_secret_message(string) do
-            ast = to_ast(string)
-            {_, acc} = Macro.prewalk(ast, [], &decode_secret_message_part(&1, &2))
-
-            acc
-            |> Enum.reverse()
-            |> Enum.join("")
-          end
-        end,
-        defmodule TopSecret do
-          def decode_secret_message(string) do
-            ast = to_ast(string)
-
-            {_, acc} =
-              Macro.prewalk(ast, [], fn ast, acc -> decode_secret_message_part(ast, acc) end)
-
-            acc
-            |> Enum.reverse()
-            |> Enum.join("")
-          end
-        end
-      ]
-    end
-  end
 end


### PR DESCRIPTION
Closes #218.

I found some exceptions to the rule for functions or notations that cannot use the captured notation `&foo/2`, and I do wonder if there are more. I ran it on every exemploid and found some bugs (and some things to fix, see #218), maybe I should run the check on a bigger codebase? What's a good one for that use?

I'll make the `website-copy` comment tomorrow.