### PR TITLE
Look for multiline strings in high-school-sweetheart

### DIFF
--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -89,6 +89,7 @@ defmodule ElixirAnalyzer.Constants do
 
     # High School Sweetheart Comments
     high_school_sweetheart_function_reuse: "elixir.high-school-sweetheart.function_reuse",
+    high_school_sweetheart_multiline_string: "elixir.high-school-sweetheart.multiline_string",
 
     # Language List Comments
     language_list_do_not_use_enum: "elixir.language-list.do_not_use_enum",

--- a/lib/elixir_analyzer/test_suite/high_school_sweetheart.ex
+++ b/lib/elixir_analyzer/test_suite/high_school_sweetheart.ex
@@ -4,6 +4,7 @@ defmodule ElixirAnalyzer.TestSuite.HighSchoolSweetheart do
   """
 
   alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.Source
 
   use ElixirAnalyzer.ExerciseTest
 
@@ -26,5 +27,15 @@ defmodule ElixirAnalyzer.TestSuite.HighSchoolSweetheart do
     calling_fn module: HighSchoolSweetheart, name: :pair
     called_fn name: :initials
     comment Constants.high_school_sweetheart_function_reuse()
+  end
+
+  check_source "uses a multiline string in pair/2" do
+    type :actionable
+    comment Constants.high_school_sweetheart_multiline_string()
+
+    check(%Source{code_string: code_string}) do
+      String.contains?(code_string, ~s(""")) ||
+        String.contains?(code_string, ~s('''))
+    end
   end
 end

--- a/test/elixir_analyzer/test_suite/high_school_sweetheart_test.exs
+++ b/test/elixir_analyzer/test_suite/high_school_sweetheart_test.exs
@@ -161,4 +161,185 @@ defmodule ElixirAnalyzer.TestSuite.HighSchoolSweetheartTest do
       ]
     end
   end
+
+  describe "multiline string" do
+    test_exercise_analysis "accepts different ways of writing multiline strings with interpolation",
+      comments_exclude: [Constants.high_school_sweetheart_multiline_string()] do
+      [
+        ~S'''
+        def pair(full_name1, full_name2) do
+          i1 = initials(full_name1)
+          i2 = initials(full_name2)
+          """
+               ******       ******
+             **      **   **      **
+           **         ** **         **
+          **            *            **
+          **                         **
+          **     #{i1}  +  #{i2}     **
+           **                       **
+             **                   **
+               **               **
+                 **           **
+                   **       **
+                     **   **
+                       ***
+                        *
+          """
+        end
+        ''',
+        ~S'''
+        def pair(full_name1, full_name2) do
+          ~s"""
+               ******       ******
+             **      **   **      **
+           **         ** **         **
+          **            *            **
+          **                         **
+          **     #{initials(full_name1)}  +  #{initials(full_name2)}     **
+           **                       **
+             **                   **
+               **               **
+                 **           **
+                   **       **
+                     **   **
+                       ***
+                        *
+          """
+        end
+        ''',
+        ~S"""
+        def pair(full_name1, full_name2) do
+          i1 = initials(full_name1)
+          i2 = initials(full_name2)
+          '''
+               ******       ******
+             **      **   **      **
+           **         ** **         **
+          **            *            **
+          **                         **
+          **     #{i1}  +  #{i2}     **
+           **                       **
+             **                   **
+               **               **
+                 **           **
+                   **       **
+                     **   **
+                       ***
+                        *
+          '''
+        end
+        """,
+        ~S"""
+        def pair(full_name1, full_name2) do
+          x1 = initials(full_name1)
+          x2 = initials(full_name2)
+          ~s'''
+               ******       ******
+             **      **   **      **
+           **         ** **         **
+          **            *            **
+          **                         **
+          **     #{x1}  +  #{x2}     **
+           **                       **
+             **                   **
+               **               **
+                 **           **
+                   **       **
+                     **   **
+                       ***
+                        *
+          '''
+        end
+        """
+      ]
+    end
+
+    test_exercise_analysis "doesn't care if the string is weirdly split",
+      comments_exclude: [Constants.high_school_sweetheart_multiline_string()] do
+      ~S'''
+      def pair(full_name1, full_name2) do
+        i1 = initials(full_name1)
+        i2 = initials(full_name2)
+
+        """
+             ******       ******
+           **      **   **      **
+         **         ** **         **
+        **            *            **
+        **                         **
+        """ <>
+          "**     #{i1}  +  #{i2}     **" <>
+          """
+
+           **                       **
+             **                   **
+               **               **
+                 **           **
+                   **       **
+                     **   **
+                       ***
+                        *
+          """
+      end
+      '''
+    end
+
+    test_exercise_analysis "correctly detects multiline string in 'one line' function",
+      comments_exclude: [Constants.high_school_sweetheart_multiline_string()] do
+      ~S'''
+      def pair(full_name1, full_name2), do:
+        """
+             ******       ******
+           **      **   **      **
+         **         ** **         **
+        **            *            **
+        **                         **
+        **     #{initials(full_name1)}  +  #{initials(full_name2)}     **
+         **                       **
+           **                   **
+             **               **
+               **           **
+                 **       **
+                   **   **
+                     ***
+                      *
+        """
+      '''
+    end
+
+    test_exercise_analysis "detects lack of multiline strings",
+      comments_include: [Constants.high_school_sweetheart_multiline_string()] do
+      [
+        defmodule HighSchoolSweetheart do
+          def pair(full_name1, full_name2) do
+            i1 = initials(full_name1)
+            i2 = initials(full_name2)
+
+            "     ******       ******\n   **      **   **      **\n **         ** **         **\n**            *            **\n**                         **\n**     #{i1}  +  #{i2}     **\n **                       **\n   **                   **\n     **               **\n       **           **\n         **       **\n           **   **\n             ***\n              *\n"
+          end
+        end,
+        defmodule HighSchoolSweetheart do
+          def pair(full_name1, full_name2),
+            do:
+              "     ******       ******\n   **      **   **      **\n **         ** **         **\n**            *            **\n**                         **\n**     #{initials(full_name1)}  +  #{initials(full_name2)}     **\n **                       **\n   **                   **\n     **               **\n       **           **\n         **       **\n           **   **\n             ***\n              *\n"
+        end
+      ]
+    end
+
+    test_exercise_analysis "doesn't get fooled by documentation",
+      comments_include: [Constants.high_school_sweetheart_multiline_string()] do
+      ~S'''
+      @doc """
+      draws a heart
+      """
+      def pair(full_name1, full_name2) do
+        i1 = initials(full_name1)
+        i2 = initials(full_name2)
+
+        "     ******       ******\n   **      **   **      **\n **         ** **         **\n**            *            **\n**                         **\n**     #{i1}  +  #{i2}     **\n **                       **\n   **                   **\n     **               **\n       **           **\n         **       **\n           **   **\n             ***\n              *\n"
+      end
+      '''
+    end
+  end
 end

--- a/test/elixir_analyzer/test_suite/high_school_sweetheart_test.exs
+++ b/test/elixir_analyzer/test_suite/high_school_sweetheart_test.exs
@@ -327,9 +327,17 @@ defmodule ElixirAnalyzer.TestSuite.HighSchoolSweetheartTest do
       ]
     end
 
-    test_exercise_analysis "doesn't get fooled by documentation",
-      comments_include: [Constants.high_school_sweetheart_multiline_string()] do
+    test_exercise_analysis "gets fooled by documentation",
+      comments_exclude: [Constants.high_school_sweetheart_multiline_string()] do
       ~S'''
+      @moduledoc """
+      Exercism exercise solution
+      """
+      @typedoc """
+      I am a rebel and I don't want to accept that the string() type is not a string
+      so I am defining my own string type!
+      """
+      @type str :: binary()
       @doc """
       draws a heart
       """


### PR DESCRIPTION
Closes https://github.com/exercism/elixir-analyzer/issues/86

i went for a very naive implementation that can be easily fooled by documentation, using multiline strings or just using any string that contains the heredoc syntax delimiters, e.g. `~s(""")`.

The module `Code.Formatter` is private and produces insane output that I don't want to parse... I don't want this check to break if we update Elixir versions.

I also gave up on writing a regex that would try to match that the string is inside of the correct function because a) I doubt my regex skills, b) that would produce false-positives when a private helper has the string.

Website copy PR: https://github.com/exercism/website-copy/pull/2130