### PR TITLE
Remove `top-secret` function capture comment

### DIFF
--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -157,7 +157,6 @@ defmodule ElixirAnalyzer.Constants do
 
     # Top Secret Comments
     top_secret_function_reuse: "elixir.top-secret.function_reuse",
-    top_secret_function_capture: "elixir.top-secret.function_capture",
 
     # Wine Cellar Comments
     wine_cellar_use_keyword_get_values: "elixir.wine-cellar.use_keyword_get_values",


### PR DESCRIPTION
I forgot to remove it in my last PR, it currently makes every CI test fail.
Those are the dangers of making changes after a PR is approved and not re-running the tests. I apologize, lesson learned.