### PR TITLE
Add analyzer check for `remote-control-car`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -84,6 +84,9 @@ config :elixir_analyzer,
     "pacman-rules" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.PacmanRules
     },
+    "remote-control-car" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.RemoteControlCar
+    },
     "rpg-character-sheet" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.RpgCharacterSheet
     },

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -135,6 +135,9 @@ defmodule ElixirAnalyzer.Constants do
     pacman_rules_use_strictly_boolean_operators:
       "elixir.pacman-rules.use_strictly_boolean_operators",
 
+    # Remote Control Car Comments
+    remote_control_car_use_default_argument: "elixir.remote-control-car.use_default_argument",
+
     # RPG Character Sheet
     rpg_character_sheet_welcome_ends_with_IO_puts:
       "elixir.rpg-character-sheet.welcome_ends_with_IO_puts",

--- a/lib/elixir_analyzer/test_suite/remote_control_car.ex
+++ b/lib/elixir_analyzer/test_suite/remote_control_car.ex
@@ -1,0 +1,34 @@
+defmodule ElixirAnalyzer.TestSuite.RemoteControlCar do
+  @moduledoc """
+  This is an exercise analyzer extension module for the exercise Remote Control Car
+  """
+
+  alias ElixirAnalyzer.Constants
+
+  use ElixirAnalyzer.ExerciseTest
+
+  feature "new uses default parameter" do
+    find :any
+    type :actionable
+    comment Constants.remote_control_car_use_default_argument()
+
+    # function header
+    form do
+      def new(_ignore \\ "none")
+    end
+
+    # function without a guard and with a do block
+    form do
+      def new(_ignore \\ "none") do
+        _ignore
+      end
+    end
+
+    # function with do block
+    form do
+      def new(_ignore \\ "none") when _ignore do
+        _ignore
+      end
+    end
+  end
+end

--- a/test/elixir_analyzer/test_suite/remote_control_car_test.exs
+++ b/test/elixir_analyzer/test_suite/remote_control_car_test.exs
@@ -1,0 +1,77 @@
+defmodule ElixirAnalyzer.TestSuite.RemoteControlCarTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.TestSuite.RemoteControlCar
+
+  alias ElixirAnalyzer.Constants
+
+  test_exercise_analysis "perfect solution",
+    comments: [Constants.solution_same_as_exemplar()] do
+    defmodule RemoteControlCar do
+      @enforce_keys [:nickname]
+      defstruct [
+        :nickname,
+        battery_percentage: 100,
+        distance_driven_in_meters: 0
+      ]
+
+      def new(nickname \\ "none") do
+        %RemoteControlCar{nickname: nickname}
+      end
+
+      def display_distance(%RemoteControlCar{distance_driven_in_meters: d}) do
+        "#{d} meters"
+      end
+
+      def display_battery(%RemoteControlCar{battery_percentage: 0}) do
+        "Battery empty"
+      end
+
+      def display_battery(%RemoteControlCar{battery_percentage: b}) do
+        "Battery at #{b}%"
+      end
+
+      def drive(%RemoteControlCar{battery_percentage: b} = r) when b > 0 do
+        d = r.distance_driven_in_meters
+        %{r | battery_percentage: b - 1, distance_driven_in_meters: d + 20}
+      end
+
+      def drive(%RemoteControlCar{} = r), do: r
+    end
+  end
+
+  test_exercise_analysis "using default arguments for new",
+    comments: [] do
+    [
+      defmodule RemoteControlCar do
+        def new(nickname \\ "none") do
+          %RemoteControlCar{nickname: nickname}
+        end
+      end,
+      defmodule RemoteControlCar do
+        def new(nickname \\ "none")
+
+        def new(nickname) do
+          %RemoteControlCar{nickname: nickname}
+        end
+      end,
+      defmodule RemoteControlCar do
+        def new(nickname \\ "none") when is_binary(nickname) do
+          %RemoteControlCar{nickname: nickname}
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "not using default arguments for new",
+    comments: [Constants.remote_control_car_use_default_argument()] do
+    defmodule RemoteControlCar do
+      def new() do
+        %RemoteControlCar{nickname: "none"}
+      end
+
+      def new(nickname) do
+        %RemoteControlCar{nickname: nickname}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #239.
[Comment PR here](https://github.com/exercism/website-copy/pull/2140).

The CI tests cannot pass until #240 is merged because the problem described in #239.
