### PR TITLE
Add analyzer module for DNA encoding exercise

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -39,6 +39,9 @@ config :elixir_analyzer,
     "chessboard" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.Chessboard
     },
+    "dna-encoding" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.DNA
+    },
     "file-sniffer" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.FileSniffer
     },

--- a/config/config.exs
+++ b/config/config.exs
@@ -40,7 +40,7 @@ config :elixir_analyzer,
       analyzer_module: ElixirAnalyzer.TestSuite.Chessboard
     },
     "dna-encoding" => %{
-      analyzer_module: ElixirAnalyzer.TestSuite.DNA
+      analyzer_module: ElixirAnalyzer.TestSuite.DNAEncoding
     },
     "file-sniffer" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.FileSniffer

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -66,6 +66,9 @@ defmodule ElixirAnalyzer.Constants do
     captains_log_use_rand_uniform: "elixir.captains-log.use_rand_uniform",
     captains_log_use_io_lib: "elixir.captains-log.use_io_lib",
 
+    # DNA Encoding Comments
+    dna_encoding_use_recursion: "elixir.dna-encoding.use_recursion",
+
     # File Sniffer Comments
     file_sniffer_use_pattern_matching: "elixir.file-sniffer.use_pattern_matching",
 

--- a/lib/elixir_analyzer/test_suite/dna_encoding.ex
+++ b/lib/elixir_analyzer/test_suite/dna_encoding.ex
@@ -6,19 +6,25 @@ defmodule ElixirAnalyzer.TestSuite.DNAEncoding do
   use ElixirAnalyzer.ExerciseTest
   alias ElixirAnalyzer.Constants
 
-  assert_no_call "does not call Enum.reduce" do
+  assert_no_call "does not call any Enum functions" do
     type :essential
-    called_fn module: Enum, name: :reduce
+    called_fn module: Enum, name: :_
     comment Constants.dna_encoding_use_recursion()
   end
 
-  assert_no_call "does not call List.foldr" do
+  assert_no_call "does not call any Stream functions" do
     type :essential
-    called_fn module: List, name: :foldr
+    called_fn module: Stream, name: :_
     comment Constants.dna_encoding_use_recursion()
   end
 
-  assert_no_call "does not call the for/1 function" do
+  assert_no_call "does not call any List functions" do
+    type :essential
+    called_fn module: List, name: :_
+    comment Constants.dna_encoding_use_recursion()
+  end
+
+  assert_no_call "does not use list comprehensions" do
     type :essential
     called_fn name: :for
     comment Constants.dna_encoding_use_recursion()

--- a/lib/elixir_analyzer/test_suite/dna_encoding.ex
+++ b/lib/elixir_analyzer/test_suite/dna_encoding.ex
@@ -1,0 +1,26 @@
+defmodule ElixirAnalyzer.TestSuite.DNA do
+  @moduledoc """
+  This is an exercise analyzer extension module for the DNA Encoding concept exercise
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+  alias ElixirAnalyzer.Constants
+
+  assert_no_call "does not call Enum.reduce/{2,3}" do
+    type :essential
+    called_fn module: Enum, name: :reduce
+    comment Constants.dna_encoding_use_recursion()
+  end
+
+  assert_no_call "does not call List.foldr" do
+    type :essential
+    called_fn module: List, name: :foldr
+    comment Constants.dna_encoding_use_recursion()
+  end
+
+  assert_no_call "does not call the for/1 function" do
+    type :essential
+    called_fn name: :for
+    comment Constants.dna_encoding_use_recursion()
+  end
+end

--- a/lib/elixir_analyzer/test_suite/dna_encoding.ex
+++ b/lib/elixir_analyzer/test_suite/dna_encoding.ex
@@ -6,7 +6,7 @@ defmodule ElixirAnalyzer.TestSuite.DNA do
   use ElixirAnalyzer.ExerciseTest
   alias ElixirAnalyzer.Constants
 
-  assert_no_call "does not call Enum.reduce/{2,3}" do
+  assert_no_call "does not call Enum.reduce" do
     type :essential
     called_fn module: Enum, name: :reduce
     comment Constants.dna_encoding_use_recursion()

--- a/lib/elixir_analyzer/test_suite/dna_encoding.ex
+++ b/lib/elixir_analyzer/test_suite/dna_encoding.ex
@@ -1,4 +1,4 @@
-defmodule ElixirAnalyzer.TestSuite.DNA do
+defmodule ElixirAnalyzer.TestSuite.DNAEncoding do
   @moduledoc """
   This is an exercise analyzer extension module for the DNA Encoding concept exercise
   """

--- a/test/elixir_analyzer/test_suite/dna_encoding_test.exs
+++ b/test/elixir_analyzer/test_suite/dna_encoding_test.exs
@@ -56,7 +56,7 @@ defmodule ElixirAnalyzer.ExerciseTest.DNAEncodingTest do
     end
   end
 
-  test_exercise_analysis "detecs Enum.reduce",
+  test_exercise_analysis "detects the usage of the Enum module",
     comments: [Constants.dna_encoding_use_recursion()] do
     [
       defmodule DNA do
@@ -65,6 +65,7 @@ defmodule ElixirAnalyzer.ExerciseTest.DNAEncodingTest do
         def encode_nucleotide(?C), do: 0b0010
         def encode_nucleotide(?G), do: 0b0100
         def encode_nucleotide(?T), do: 0b1000
+
         def decode_nucleotide(0b0000), do: ?\s
         def decode_nucleotide(0b0001), do: ?A
         def decode_nucleotide(0b0010), do: ?C
@@ -78,49 +79,53 @@ defmodule ElixirAnalyzer.ExerciseTest.DNAEncodingTest do
         end
 
         def decode(dna) do
-          for <<ns::4 <- dna>> do
-            decode_nucleotide(ns)
-          end
+          do_decode(dna, [])
         end
+
+        defp do_decode(<<>>, acc), do: acc |> reverse()
+
+        defp do_decode(<<n::4, rest::bitstring>>, acc),
+          do: do_decode(rest, [decode_nucleotide(n) | acc])
+
+        defp reverse(l), do: do_reverse(l, [])
+        defp do_reverse([], acc), do: acc
+        defp do_reverse([h | t], acc), do: do_reverse(t, [h | acc])
       end
     ]
   end
 
-  test_exercise_analysis "detects List.foldr",
-    comments: [Constants.dna_encoding_use_recursion(), Constants.solution_use_function_capture()] do
+  test_exercise_analysis "detects the usage of the List module",
+    comments: [Constants.dna_encoding_use_recursion()] do
     [
       defmodule DNA do
-        @acids %{
-          ?\s => 0b0000,
-          ?A => 0b0001,
-          ?C => 0b0010,
-          ?G => 0b0100,
-          ?T => 0b1000
-        }
+        def encode_nucleotide(?\s), do: 0b0000
+        def encode_nucleotide(?A), do: 0b0001
+        def encode_nucleotide(?C), do: 0b0010
+        def encode_nucleotide(?G), do: 0b0100
+        def encode_nucleotide(?T), do: 0b1000
 
-        def encode_nucleotide(code_point), do: @acids[code_point]
-
-        def decode_nucleotide(encoded_code) do
-          {key, _} = Enum.find(@acids, nil, fn {_, code} -> code == encoded_code end)
-          key
-        end
+        def decode_nucleotide(0b0000), do: ?\s
+        def decode_nucleotide(0b0001), do: ?A
+        def decode_nucleotide(0b0010), do: ?C
+        def decode_nucleotide(0b0100), do: ?G
+        def decode_nucleotide(0b1000), do: ?T
 
         def encode(dna) do
-          Enum.map(dna, &encode_nucleotide(&1))
-          |> List.foldr(<<0::0>>, &<<&1::4, &2::bitstring>>)
+          List.foldr(dna, <<0::0>>, &<<encode_nucleotide(&1)::4, &2::bitstring>>)
         end
 
         def decode(dna) do
           do_decode(dna, [])
-          |> Enum.reverse()
         end
 
-        defp do_decode(<<0::0>>, acc), do: acc
+        defp do_decode(<<>>, acc), do: acc |> reverse()
 
-        defp do_decode(dna, acc) do
-          <<value::4, rest::bitstring>> = dna
-          do_decode(rest, [decode_nucleotide(value) | acc])
-        end
+        defp do_decode(<<n::4, rest::bitstring>>, acc),
+          do: do_decode(rest, [decode_nucleotide(n) | acc])
+
+        defp reverse(l), do: do_reverse(l, [])
+        defp do_reverse([], acc), do: acc
+        defp do_reverse([h | t], acc), do: do_reverse(t, [h | acc])
       end
     ]
   end
@@ -141,10 +146,14 @@ defmodule ElixirAnalyzer.ExerciseTest.DNAEncodingTest do
         def decode_nucleotide(0b0100), do: ?G
         def decode_nucleotide(0b1000), do: ?T
 
-        def encode([]), do: <<>>
+        def encode(dna) do
+          do_encode(dna, <<>>)
+        end
 
-        def encode([nucleotide | dna]) do
-          <<encode_nucleotide(nucleotide)::4, encode(dna)::bitstring()>>
+        defp do_encode([], acc), do: acc
+
+        defp do_encode([n | rest], acc) do
+          do_encode(rest, <<acc::bitstring, encode_nucleotide(n)::4>>)
         end
 
         def decode(dna) do

--- a/test/elixir_analyzer/test_suite/dna_encoding_test.exs
+++ b/test/elixir_analyzer/test_suite/dna_encoding_test.exs
@@ -1,0 +1,180 @@
+defmodule ElixirAnalyzer.ExerciseTest.DNATest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.TestSuite.DNA
+
+  test_exercise_analysis "example solution",
+    comments: [ElixirAnalyzer.Constants.solution_same_as_exemplar()] do
+    defmodule DNA do
+      @moduledoc """
+      Example solution for the `bitstrings` exercise.
+
+      Written by Tim Austin, tim@neenjaw.com, June 2020.
+
+       | NucleicAcid | Bits |
+       | ----------- | ---- |
+       |    ' '      | 0000 |
+       |     A       | 0001 |
+       |     C       | 0010 |
+       |     G       | 0100 |
+       |     T       | 1000 |
+      """
+
+      def encode_nucleotide(?\s), do: 0b0000
+      def encode_nucleotide(?A), do: 0b0001
+      def encode_nucleotide(?C), do: 0b0010
+      def encode_nucleotide(?G), do: 0b0100
+      def encode_nucleotide(?T), do: 0b1000
+
+      def decode_nucleotide(0b0000), do: ?\s
+      def decode_nucleotide(0b0001), do: ?A
+      def decode_nucleotide(0b0010), do: ?C
+      def decode_nucleotide(0b0100), do: ?G
+      def decode_nucleotide(0b1000), do: ?T
+
+      def encode(dna) do
+        do_encode(dna, <<>>)
+      end
+
+      defp do_encode([], acc), do: acc
+
+      defp do_encode([n | rest], acc) do
+        do_encode(rest, <<acc::bitstring, encode_nucleotide(n)::4>>)
+      end
+
+      def decode(dna) do
+        do_decode(dna, [])
+      end
+
+      defp do_decode(<<>>, acc), do: acc |> reverse()
+
+      defp do_decode(<<n::4, rest::bitstring>>, acc),
+        do: do_decode(rest, [decode_nucleotide(n) | acc])
+
+      defp reverse(l), do: do_reverse(l, [])
+      defp do_reverse([], acc), do: acc
+      defp do_reverse([h | t], acc), do: do_reverse(t, [h | acc])
+    end
+  end
+
+  test_exercise_analysis "detecs Enum.reduce",
+    comments: [Constants.dna_encoding_use_recursion()] do
+    [
+      defmodule DNA do
+        def encode_nucleotide(?\s), do: 0b0000
+        def encode_nucleotide(?A), do: 0b0001
+        def encode_nucleotide(?C), do: 0b0010
+        def encode_nucleotide(?G), do: 0b0100
+        def encode_nucleotide(?T), do: 0b1000
+        def decode_nucleotide(0b0000), do: ?\s
+        def decode_nucleotide(0b0001), do: ?A
+        def decode_nucleotide(0b0010), do: ?C
+        def decode_nucleotide(0b0100), do: ?G
+        def decode_nucleotide(0b1000), do: ?T
+
+        def encode(dna) do
+          dna
+          |> Enum.map(&encode_nucleotide/1)
+          |> Enum.reduce("", fn enc, bs -> <<bs::bitstring, enc::4>> end)
+        end
+
+        def decode(dna) do
+          for <<ns::4 <- dna>> do
+            decode_nucleotide(ns)
+          end
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "detects List.foldr",
+    comments: [Constants.dna_encoding_use_recursion(), Constants.solution_use_function_capture()] do
+    [
+      defmodule DNA do
+        @acids %{
+          ?\s => 0b0000,
+          ?A => 0b0001,
+          ?C => 0b0010,
+          ?G => 0b0100,
+          ?T => 0b1000
+        }
+
+        def encode_nucleotide(code_point), do: @acids[code_point]
+
+        def decode_nucleotide(encoded_code) do
+          {key, _} = Enum.find(@acids, nil, fn {_, code} -> code == encoded_code end)
+          key
+        end
+
+        def encode(dna) do
+          Enum.map(dna, &encode_nucleotide(&1))
+          |> List.foldr(<<0::0>>, &<<&1::4, &2::bitstring>>)
+        end
+
+        def decode(dna) do
+          do_decode(dna, [])
+          |> Enum.reverse()
+        end
+
+        defp do_decode(<<0::0>>, acc), do: acc
+
+        defp do_decode(dna, acc) do
+          <<value::4, rest::bitstring>> = dna
+          do_decode(rest, [decode_nucleotide(value) | acc])
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "detects list comprehensions",
+    comments: [Constants.dna_encoding_use_recursion()] do
+    [
+      defmodule DNA do
+        def encode_nucleotide(?\s), do: 0b0000
+        def encode_nucleotide(?A), do: 0b0001
+        def encode_nucleotide(?C), do: 0b0010
+        def encode_nucleotide(?G), do: 0b0100
+        def encode_nucleotide(?T), do: 0b1000
+        def decode_nucleotide(0b0000), do: ?\s
+        def decode_nucleotide(0b0001), do: ?A
+        def decode_nucleotide(0b0010), do: ?C
+        def decode_nucleotide(0b0100), do: ?G
+        def decode_nucleotide(0b1000), do: ?T
+
+        def encode(dna) do
+          dna
+          |> Enum.map(&encode_nucleotide/1)
+          |> Enum.reduce("", fn enc, bs -> <<bs::bitstring, enc::4>> end)
+        end
+
+        def decode(dna) do
+          for <<ns::4 <- dna>> do
+            decode_nucleotide(ns)
+          end
+        end
+      end,
+      defmodule DNA do
+        def encode_nucleotide(?\s), do: 0b0000
+        def encode_nucleotide(?A), do: 0b0001
+        def encode_nucleotide(?C), do: 0b0010
+        def encode_nucleotide(?G), do: 0b0100
+        def encode_nucleotide(?T), do: 0b1000
+
+        def decode_nucleotide(0b0000), do: ?\s
+        def decode_nucleotide(0b0001), do: ?A
+        def decode_nucleotide(0b0010), do: ?C
+        def decode_nucleotide(0b0100), do: ?G
+        def decode_nucleotide(0b1000), do: ?T
+
+        def encode(chars) do
+          for c <- chars, reduce: <<>> do
+            acc -> <<acc::bitstring, encode_nucleotide(c)::4>>
+          end
+        end
+
+        def decode(bin) do
+          for <<b::4 <- bin>>, into: [], do: decode_nucleotide(b)
+        end
+      end
+    ]
+  end
+end

--- a/test/elixir_analyzer/test_suite/dna_encoding_test.exs
+++ b/test/elixir_analyzer/test_suite/dna_encoding_test.exs
@@ -94,6 +94,42 @@ defmodule ElixirAnalyzer.ExerciseTest.DNAEncodingTest do
     ]
   end
 
+  test_exercise_analysis "detects the usage of the Stream module",
+    comments: [Constants.dna_encoding_use_recursion()] do
+    [
+      defmodule DNA do
+        def encode_nucleotide(?\s), do: 0b0000
+        def encode_nucleotide(?A), do: 0b0001
+        def encode_nucleotide(?C), do: 0b0010
+        def encode_nucleotide(?G), do: 0b0100
+        def encode_nucleotide(?T), do: 0b1000
+
+        def decode_nucleotide(0b0000), do: ?\s
+        def decode_nucleotide(0b0001), do: ?A
+        def decode_nucleotide(0b0010), do: ?C
+        def decode_nucleotide(0b0100), do: ?G
+        def decode_nucleotide(0b1000), do: ?T
+
+        def encode(dna) do
+          Stream.map(dna, &encode_nucleotide/1)
+        end
+
+        def decode(dna) do
+          do_decode(dna, [])
+        end
+
+        defp do_decode(<<>>, acc), do: acc |> reverse()
+
+        defp do_decode(<<n::4, rest::bitstring>>, acc),
+          do: do_decode(rest, [decode_nucleotide(n) | acc])
+
+        defp reverse(l), do: do_reverse(l, [])
+        defp do_reverse([], acc), do: acc
+        defp do_reverse([h | t], acc), do: do_reverse(t, [h | acc])
+      end
+    ]
+  end
+
   test_exercise_analysis "detects the usage of the List module",
     comments: [Constants.dna_encoding_use_recursion()] do
     [

--- a/test/elixir_analyzer/test_suite/dna_encoding_test.exs
+++ b/test/elixir_analyzer/test_suite/dna_encoding_test.exs
@@ -134,16 +134,17 @@ defmodule ElixirAnalyzer.ExerciseTest.DNATest do
         def encode_nucleotide(?C), do: 0b0010
         def encode_nucleotide(?G), do: 0b0100
         def encode_nucleotide(?T), do: 0b1000
+
         def decode_nucleotide(0b0000), do: ?\s
         def decode_nucleotide(0b0001), do: ?A
         def decode_nucleotide(0b0010), do: ?C
         def decode_nucleotide(0b0100), do: ?G
         def decode_nucleotide(0b1000), do: ?T
 
-        def encode(dna) do
-          dna
-          |> Enum.map(&encode_nucleotide/1)
-          |> Enum.reduce("", fn enc, bs -> <<bs::bitstring, enc::4>> end)
+        def encode([]), do: <<>>
+
+        def encode([nucleotide | dna]) do
+          <<encode_nucleotide(nucleotide)::4, encode(dna)::bitstring()>>
         end
 
         def decode(dna) do

--- a/test/elixir_analyzer/test_suite/dna_encoding_test.exs
+++ b/test/elixir_analyzer/test_suite/dna_encoding_test.exs
@@ -5,20 +5,6 @@ defmodule ElixirAnalyzer.ExerciseTest.DNAEncodingTest do
   test_exercise_analysis "example solution",
     comments: [ElixirAnalyzer.Constants.solution_same_as_exemplar()] do
     defmodule DNA do
-      @moduledoc """
-      Example solution for the `bitstrings` exercise.
-
-      Written by Tim Austin, tim@neenjaw.com, June 2020.
-
-       | NucleicAcid | Bits |
-       | ----------- | ---- |
-       |    ' '      | 0000 |
-       |     A       | 0001 |
-       |     C       | 0010 |
-       |     G       | 0100 |
-       |     T       | 1000 |
-      """
-
       def encode_nucleotide(?\s), do: 0b0000
       def encode_nucleotide(?A), do: 0b0001
       def encode_nucleotide(?C), do: 0b0010

--- a/test/elixir_analyzer/test_suite/dna_encoding_test.exs
+++ b/test/elixir_analyzer/test_suite/dna_encoding_test.exs
@@ -1,6 +1,6 @@
-defmodule ElixirAnalyzer.ExerciseTest.DNATest do
+defmodule ElixirAnalyzer.ExerciseTest.DNAEncodingTest do
   use ElixirAnalyzer.ExerciseTestCase,
-    exercise_test_module: ElixirAnalyzer.TestSuite.DNA
+    exercise_test_module: ElixirAnalyzer.TestSuite.DNAEncoding
 
   test_exercise_analysis "example solution",
     comments: [ElixirAnalyzer.Constants.solution_same_as_exemplar()] do

--- a/test/support/exercise_test_case.ex
+++ b/test/support/exercise_test_case.ex
@@ -216,7 +216,12 @@ defmodule ElixirAnalyzer.ExerciseTestCase do
   defp find_source_exemploid(%Source{exemploid_path: exemploid_path} = source)
        when is_binary(exemploid_path) do
     exemploid_string = File.read!(exemploid_path)
-    exemploid_ast = Code.string_to_quoted!(exemploid_string)
+
+    exemploid_ast =
+      exemploid_string
+      |> Code.format_string!(line_length: 120, force_do_end_blocks: true)
+      |> IO.iodata_to_binary()
+      |> Code.string_to_quoted!()
 
     %{source | exemploid_string: exemploid_string, exemploid_ast: exemploid_ast}
   end


### PR DESCRIPTION
Issue: https://github.com/exercism/elixir-analyzer/issues/84.

# Description:
I added checks that will prompt users to use `recursion` instead of the following modules/functions:
- `Enum.reduce`
- `List.foldr`
- `for`