### PR TITLE
Remove protocol consolidation to fix warning in valid code

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,8 @@ defmodule ElixirAnalyzer.MixProject do
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
+      # Turn off protocol consolidation to avoid warning in analyzed code
+      consolidate_protocols: false,
       deps: deps(),
       escript: escript(),
       preferred_cli_env: [

--- a/test/elixir_analyzer/exercise_test/common_checks/compiler_warnings_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/compiler_warnings_test.exs
@@ -1,0 +1,9 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.CompilerWarningsTest do
+  use ExUnit.Case
+  alias ElixirAnalyzer.ExerciseTest.CommonChecks.CompilerWarnings
+
+  test "Implementing a protocol doesn't trigger a compiler warning" do
+    filepath = "test_data/clock/lib/clock.ex"
+    assert CompilerWarnings.run(filepath, nil) == []
+  end
+end

--- a/test_data/clock/lib/clock.ex
+++ b/test_data/clock/lib/clock.ex
@@ -1,0 +1,60 @@
+defmodule Clock do
+  defstruct hour: 0, minute: 0
+  @type t :: %Clock{hour: integer, minute: integer}
+  @type t(hour, minute) :: %Clock{hour: hour, minute: minute}
+
+  @doc """
+  Returns a string representation of a clock:
+
+      iex> Clock.new(8, 9) |> to_string
+      "08:09"
+  """
+  @spec new(integer, integer) :: Clock.t()
+  def new(hour, minute) do
+    rollover(%Clock{hour: hour, minute: minute})
+  end
+
+  @doc """
+  Adds two clock times:
+
+      iex> Clock.new(10, 0) |> Clock.add(3) |> to_string
+      "10:03"
+  """
+  @spec add(Clock.t(), integer) :: Clock.t()
+  def add(%Clock{hour: hour, minute: minute}, add_minute) do
+    new(hour, minute + add_minute)
+  end
+
+  defp rollover(%Clock{hour: hour, minute: minute} = clock) do
+    case {hour, minute} do
+      {hour, minute} when minute >= 60 ->
+        %Clock{hour: hour + 1, minute: minute - 60}
+        |> rollover()
+
+      {hour, minute} when minute < 0 ->
+        %Clock{hour: hour - 1, minute: minute + 60}
+        |> rollover()
+
+      {hour, minute} when hour >= 24 ->
+        %Clock{hour: hour - 24, minute: minute}
+        |> rollover()
+
+      {hour, minute} when hour < 0 ->
+        %Clock{hour: hour + 24, minute: minute}
+        |> rollover()
+
+      _ ->
+        clock
+    end
+  end
+
+  defimpl String.Chars, for: Clock do
+    def to_string(%Clock{hour: hour, minute: minute}) do
+      "#{format(hour)}:#{format(minute)}"
+    end
+
+    defp format(number) do
+      number |> Integer.to_string() |> String.pad_leading(2, "0")
+    end
+  end
+end


### PR DESCRIPTION
Closes #251.

My initial hypothesis (in the issue) was not quite right. [Protocol consolidation](https://hexdocs.pm/elixir/Protocol.html#module-consolidation) is a feature that links protocols to their implementation in order to speed up the protocol dispatch. This can only work when all implementations are known, typically at compile time.

In the case of `clock`, when we compile the file in `ElixirAnalyzer.ExerciseTest.CommonChecks.CompilerWarnings`, an extra implementation is defined and the compiler refuses to include it because the "protocol has already been consolidated" at compile time. 

The docs only show how to turn it off for tests, so I brought my hammer for this fix and I turned off the consolidation altogether. The tradeoff is supposedly a performance cost, but I didn't notice any difference. I'm of course open to other ideas.