### PR TITLE
Only comment on explicit `:ok` in `rpg-character-sheet` and `newsletter`

### DIFF
--- a/lib/elixir_analyzer/test_suite/newsletter.ex
+++ b/lib/elixir_analyzer/test_suite/newsletter.ex
@@ -9,12 +9,13 @@ defmodule ElixirAnalyzer.TestSuite.Newsletter do
 
   feature "close_log ends with File.close" do
     type :actionable
+    find :none
     comment Constants.newsletter_close_log_returns_implicitly()
 
     form do
       def close_log(_ignore) do
         _block_ends_with do
-          File.close(_ignore)
+          :ok
         end
       end
     end
@@ -43,13 +44,14 @@ defmodule ElixirAnalyzer.TestSuite.Newsletter do
 
   feature "log_sent_email ends with IO.puts" do
     type :actionable
+    find :none
     comment Constants.newsletter_log_sent_email_returns_implicitly()
     suppress_if "use IO.puts in log_sent_email rather than IO.write as last call", :fail
 
     form do
       def log_sent_email(_ignore, _ignore) do
         _block_ends_with do
-          IO.puts(_ignore, _ignore)
+          :ok
         end
       end
     end

--- a/lib/elixir_analyzer/test_suite/newsletter.ex
+++ b/lib/elixir_analyzer/test_suite/newsletter.ex
@@ -90,6 +90,22 @@ defmodule ElixirAnalyzer.TestSuite.Newsletter do
         end
       end
     end
+
+    form do
+      def open_log(_ignore) do
+        _block_includes do
+          open(_ignore, [:write])
+        end
+      end
+    end
+
+    form do
+      def open_log(_ignore) do
+        _block_includes do
+          open!(_ignore, [:write])
+        end
+      end
+    end
   end
 
   assert_call "send_newsletter/3 calls open_log/1" do

--- a/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
+++ b/lib/elixir_analyzer/test_suite/rpg_character_sheet.ex
@@ -10,22 +10,14 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheet do
 
   feature "welcome ends with IO.puts" do
     type :actionable
-    find :any
+    find :none
     depth 1
     comment Constants.rpg_character_sheet_welcome_ends_with_IO_puts()
 
     form do
       def welcome() do
         _block_ends_with do
-          IO.puts(_ignore)
-        end
-      end
-    end
-
-    form do
-      def welcome() do
-        _block_ends_with do
-          IO.write(_ignore)
+          :ok
         end
       end
     end

--- a/test/elixir_analyzer/test_suite/newsletter_test.exs
+++ b/test/elixir_analyzer/test_suite/newsletter_test.exs
@@ -83,27 +83,6 @@ defmodule ElixirAnalyzer.ExerciseTest.NewsletterTest do
         end,
         defmodule Newsletter do
           def log_sent_email(pid, email) do
-            x = :ok
-            IO.write(pid, email <> "\n")
-            x
-          end
-        end,
-        defmodule Newsletter do
-          def log_sent_email(pid, email) do
-            x = IO.write(pid, email)
-            x = IO.write(pid, "\n")
-            x
-          end
-        end,
-        defmodule Newsletter do
-          def log_sent_email(pid, email) do
-            x = IO.write(pid, email)
-            x = IO.puts(pid, "")
-            x
-          end
-        end,
-        defmodule Newsletter do
-          def log_sent_email(pid, email) do
             IO.write(pid, email)
             IO.puts(pid, "")
             :ok
@@ -122,12 +101,6 @@ defmodule ElixirAnalyzer.ExerciseTest.NewsletterTest do
             File.close(pid)
             :ok
           end
-        end,
-        defmodule Newsletter do
-          def close_log(pid) do
-            x = File.close(pid)
-            x
-          end
         end
       ]
     end
@@ -139,12 +112,6 @@ defmodule ElixirAnalyzer.ExerciseTest.NewsletterTest do
           def log_sent_email(pid, email) do
             IO.puts(pid, email)
             :ok
-          end
-        end,
-        defmodule Newsletter do
-          def log_sent_email(pid, email) do
-            x = IO.puts(pid, email)
-            x
           end
         end
       ]

--- a/test/elixir_analyzer/test_suite/newsletter_test.exs
+++ b/test/elixir_analyzer/test_suite/newsletter_test.exs
@@ -39,6 +39,46 @@ defmodule ElixirAnalyzer.ExerciseTest.NewsletterTest do
     end
   end
 
+  test_exercise_analysis "other solution",
+    comments: [] do
+    defmodule Newsletter do
+      import File
+      import IO
+
+      def read_emails(path) do
+        path
+        |> read!()
+        |> String.split()
+      end
+
+      def open_log(path) do
+        open!(path, [:write])
+      end
+
+      def log_sent_email(pid, email) do
+        puts(pid, email)
+      end
+
+      def close_log(pid) do
+        close(pid)
+      end
+
+      def send_newsletter(emails_path, log_path, send_fun) do
+        log_pid = open_log(log_path)
+        emails = read_emails(emails_path)
+
+        Enum.each(emails, fn email ->
+          case send_fun.(email) do
+            :ok -> log_sent_email(log_pid, email)
+            _ -> nil
+          end
+        end)
+
+        close_log(log_pid)
+      end
+    end
+  end
+
   describe "using IO.write in log_sent_email" do
     test_exercise_analysis "recommends IO.puts over IO.write",
       comments_include: [Constants.newsletter_log_sent_email_prefer_io_puts()],

--- a/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
+++ b/test/elixir_analyzer/test_suite/rpg_character_sheet_test.exs
@@ -145,6 +145,39 @@ defmodule ElixirAnalyzer.TestSuite.RpgCharacterSheetTest do
           |> IO.gets()
           |> String.trim()
         end
+      end,
+      defmodule RPG.CharacterSheet do
+        import IO
+
+        def welcome() do
+          puts("Welcome! Let's fill out your character sheet together.")
+        end
+
+        def ask_name() do
+          gets("What is your character's name?\n") |> String.trim()
+        end
+
+        def ask_class() do
+          gets("What is your character's class?\n") |> String.trim()
+        end
+
+        def ask_level() do
+          gets("What is your character's level?\n") |> String.trim() |> String.to_integer()
+        end
+
+        def run() do
+          welcome()
+          name = ask_name()
+          class = ask_class()
+          level = ask_level()
+
+          %{
+            name: name,
+            class: class,
+            level: level
+          }
+          |> IO.inspect(label: "Your character")
+        end
       end
     ]
   end


### PR DESCRIPTION
Closes #250.

The issue only mentioned `rpg-character-sheet` but `newsletter` was using the same pattern so I changed it too.

This is not the first time those comments are misleading students, so I thought it would be best to only send a comment to solutions we 100% know are not what we want. It does mean we might be missing some cases (like the tests I had to remove), hopefully not too many. 

I think it's a fair tradeoff, but I'm happy to discuss that choice.