### PR TITLE
Remove `status` and `meta` from `feature`

### DIFF
--- a/docs/step-02/step-02.md
+++ b/docs/step-02/step-02.md
@@ -46,17 +46,17 @@ Then we can run the elixir analyzer:
 Compiling 2 files (.ex)
 Generated escript elixir_analyzer with MIX_ENV=dev
 
-> ./elixir_analyzer --analyze-file "<path>/02-example-module.ex:Example"
+> ./elixir_analyzer example-slug path/to/example/folder path/to/output 
 undefined analysis ... Completed!
 
 Analysis ... Analysis Complete
-Output written to ... <path>/analysis.json
+Output written to ... path/to/output/analysis.json
 ```
 
 We can then find `analysis.json` at the path specified with the contents:
 
 ```json
-{ "comments": [], "status": "approve" }
+{"comments": [],"summary":"Submission analyzed. No automated suggestions found."}
 ```
 
 ---

--- a/docs/step-04/04-example-analysis-test.exs
+++ b/docs/step-04/04-example-analysis-test.exs
@@ -3,7 +3,6 @@ defmodule ElixirAnalyzer.TestSuite.ExampleTest do
       exercise_test_module: ElixirAnalyzer.TestSuite.Example
 
   test_exercise_analysis "perfect solution",
-    status: :approve,
     comments: [] do
     defmodule Example do
       @moduledoc """

--- a/lib/elixir_analyzer/comment.ex
+++ b/lib/elixir_analyzer/comment.ex
@@ -10,7 +10,6 @@ defmodule ElixirAnalyzer.Comment do
           name: String.t(),
           comment: String.t(),
           type: :essential | :actionable | :informative | :celebratory,
-          status: :skip | :test,
           suppress_if: false | {String.t(), :pass | :fail},
           params: map() | nil
         }

--- a/lib/elixir_analyzer/exercise_test.ex
+++ b/lib/elixir_analyzer/exercise_test.ex
@@ -102,9 +102,6 @@ defmodule ElixirAnalyzer.ExerciseTest do
 
       defp append_test_comments(%Submission{} = submission, results) do
         Enum.reduce(results, submission, fn
-          {:skip, _description}, submission ->
-            submission
-
           {:pass, %Comment{} = comment}, submission ->
             if Map.get(comment, :type, false) == :celebratory do
               Submission.append_comment(submission, comment)

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -33,7 +33,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
     end
   end
 
-  @spec run(Source.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Source.t()) :: [{:pass | :fail, Comment.t()}]
   def run(%Source{
         code_path: code_path,
         code_ast: code_ast,

--- a/lib/elixir_analyzer/exercise_test/common_checks/boolean_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/boolean_functions.ex
@@ -11,7 +11,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.BooleanFunctions do
   alias ElixirAnalyzer.Constants
   alias ElixirAnalyzer.Comment
 
-  @spec run(Macro.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t()) :: [{:pass | :fail, Comment.t()}]
   def run(ast) do
     {_, function_names} =
       Macro.prewalk(ast, %{defs: [], defguards: [], defmacros: []}, &traverse/2)

--- a/lib/elixir_analyzer/exercise_test/common_checks/comments.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/comments.ex
@@ -6,7 +6,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.Comments do
   alias ElixirAnalyzer.Constants
   alias ElixirAnalyzer.Comment
 
-  @spec run(Macro.t(), String.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t(), String.t()) :: [{:pass | :fail, Comment.t()}]
   def run(ast, string) do
     boilerplate_comment_check =
       if has_comment_matching_pattern?(

--- a/lib/elixir_analyzer/exercise_test/common_checks/exemplar_comparison.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/exemplar_comparison.ex
@@ -7,7 +7,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ExemplarComparison do
   alias ElixirAnalyzer.Constants
   alias ElixirAnalyzer.Comment
 
-  @spec run(Macro.t(), atom, Macro.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t(), atom, Macro.t()) :: [{:pass | :fail, Comment.t()}]
 
   def run(code_ast, :concept, exemplar_ast) do
     if format(code_ast) == format(exemplar_ast) do

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
@@ -6,7 +6,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCapture do
   alias ElixirAnalyzer.Constants
   alias ElixirAnalyzer.Comment
 
-  @spec run(Macro.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t()) :: [{:pass | :fail, Comment.t()}]
   def run(code_ast) do
     acc = %{capture_depth: 0, functions: []}
 

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_names.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_names.ex
@@ -13,7 +13,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionNames do
 
   @def_ops [:def, :defp, :defmacro, :defmacrop, :defguard, :defguardp]
 
-  @spec run(Macro.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t()) :: [{:pass | :fail, Comment.t()}]
   def run(ast) do
     {_, names} = Macro.prewalk(ast, [], &traverse/2)
     wrong_name = List.last(names)

--- a/lib/elixir_analyzer/exercise_test/common_checks/indentation.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/indentation.ex
@@ -6,7 +6,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.Indentation do
   alias ElixirAnalyzer.Constants
   alias ElixirAnalyzer.Comment
 
-  @spec run(Macro.t(), String.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t(), String.t()) :: [{:pass | :fail, Comment.t()}]
   def run(ast, string) do
     if uses_tabs_for_indentation?(ast, string) do
       [

--- a/lib/elixir_analyzer/exercise_test/common_checks/module_attribute_names.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/module_attribute_names.ex
@@ -11,7 +11,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModuleAttributeNames do
   alias ElixirAnalyzer.Constants
   alias ElixirAnalyzer.Comment
 
-  @spec run(Macro.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t()) :: [{:pass | :fail, Comment.t()}]
   def run(ast) do
     {_, names} = Macro.prewalk(ast, [], &traverse/2)
     wrong_name = List.last(names)

--- a/lib/elixir_analyzer/exercise_test/common_checks/module_pascal_case.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/module_pascal_case.ex
@@ -11,7 +11,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.ModulePascalCase do
   alias ElixirAnalyzer.Constants
   alias ElixirAnalyzer.Comment
 
-  @spec run(Macro.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t()) :: [{:pass | :fail, Comment.t()}]
   def run(ast) do
     {_, names} = Macro.prewalk(ast, [], &traverse/2)
     wrong_name = List.last(names)

--- a/lib/elixir_analyzer/exercise_test/common_checks/private_helper_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/private_helper_functions.ex
@@ -8,7 +8,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.PrivateHelperFunctions do
 
   @public_ops [:def, :defmacro, :defguard]
 
-  @spec run(Macro.t(), nil | Macro.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t(), nil | Macro.t()) :: [{:pass | :fail, Comment.t()}]
   def run(_ast, nil), do: []
 
   def run(code_ast, exemploid_ast) do

--- a/lib/elixir_analyzer/exercise_test/common_checks/variable_names.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/variable_names.ex
@@ -11,7 +11,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.VariableNames do
   alias ElixirAnalyzer.Constants
   alias ElixirAnalyzer.Comment
 
-  @spec run(Macro.t()) :: [{:pass | :fail | :skip, Comment.t()}]
+  @spec run(Macro.t()) :: [{:pass | :fail, Comment.t()}]
   def run(ast) do
     {_, %{variable_names: variable_names, false_positives: false_positives}} =
       Macro.prewalk(ast, %{variable_names: [], false_positives: []}, &traverse/2)

--- a/lib/elixir_analyzer/exercise_test/feature/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/feature/compiler.ex
@@ -8,7 +8,6 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.Compiler do
   def compile({feature_data, feature_forms}, code_ast) do
     name = Keyword.fetch!(feature_data, :name)
     comment = Keyword.fetch!(feature_data, :comment)
-    status = Keyword.get(feature_data, :status, :test)
     type = Keyword.get(feature_data, :type, :informative)
     find_type = Keyword.get(feature_data, :find, :all)
     find_at_depth = Keyword.get(feature_data, :depth, nil)
@@ -24,25 +23,16 @@ defmodule ElixirAnalyzer.ExerciseTest.Feature.Compiler do
       Macro.escape(%Comment{
         name: name,
         comment: comment,
-        status: status,
         type: type,
         suppress_if: suppress_if
       })
 
-    case status do
-      :test ->
-        quote do
-          if unquote(form_expr) do
-            {:pass, unquote(test_description)}
-          else
-            {:fail, unquote(test_description)}
-          end
-        end
-
-      :skip ->
-        quote do
-          {:skip, unquote(test_description)}
-        end
+    quote do
+      if unquote(form_expr) do
+        {:pass, unquote(test_description)}
+      else
+        {:fail, unquote(test_description)}
+      end
     end
   end
 

--- a/lib/elixir_analyzer/test_suite/two_fer.ex
+++ b/lib/elixir_analyzer/test_suite/two_fer.ex
@@ -14,7 +14,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   #
 
   feature "has spec" do
-    # status :skip
     find :all
     type :actionable
     comment Constants.solution_use_specification()
@@ -25,7 +24,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   end
 
   feature "has wrong spec" do
-    # status      :skip
     find :all
     type :actionable
     suppress_if "has spec", :fail
@@ -37,7 +35,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   end
 
   feature "has default parameter" do
-    # status :skip
     find :any
     type :actionable
     comment Constants.two_fer_use_default_parameter()
@@ -63,7 +60,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   end
 
   feature "uses function header" do
-    # status   :skip
     find :none
     type :actionable
     comment Constants.two_fer_use_of_function_header()
@@ -74,7 +70,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   end
 
   feature "uses guards" do
-    # status :skip
     find :any
     type :actionable
     comment Constants.two_fer_use_guards()
@@ -89,7 +84,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   end
 
   feature "uses function level guard" do
-    # status      :skip
     find :any
     type :actionable
     suppress_if "uses guards", :fail
@@ -113,7 +107,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   end
 
   feature "uses auxiliary functions" do
-    # status   :skip
     find :none
     type :actionable
     comment Constants.two_fer_use_of_aux_functions()
@@ -124,7 +117,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   end
 
   feature "uses string interpolation" do
-    # status :skip
     find :any
     type :actionable
     comment Constants.two_fer_use_string_interpolation()
@@ -135,7 +127,6 @@ defmodule ElixirAnalyzer.TestSuite.TwoFer do
   end
 
   feature "first level @moduledoc recommended" do
-    # status :skip
     find :all
     type :informative
     comment Constants.solution_use_moduledoc()

--- a/test/elixir_analyzer/exercise_test/feature_test.exs
+++ b/test/elixir_analyzer/exercise_test/feature_test.exs
@@ -450,15 +450,6 @@ defmodule ElixirAnalyzer.ExerciseTest.FeatureTest do
     defmodule Coverage do
       use ElixirAnalyzer.ExerciseTest
 
-      feature "skip" do
-        comment "skip"
-        status :skip
-
-        form do
-          :ok
-        end
-      end
-
       feature "any" do
         comment "any"
         find :any
@@ -511,15 +502,6 @@ defmodule ElixirAnalyzer.ExerciseTest.FeatureTest do
           :ok
         end
       end
-
-      feature "meta" do
-        comment "meta"
-        meta(keep_meta(true))
-
-        form do
-          def foo, do: :ok
-        end
-      end
     end
 
     defmodule CoverageTest do
@@ -527,16 +509,16 @@ defmodule ElixirAnalyzer.ExerciseTest.FeatureTest do
         exercise_test_module: Coverage
 
       test_exercise_analysis "has :ok at depth 2",
-        comments: ["meta", "depth 3", "all", "suppress_if"],
-        comments_exclude: ["any", "depth 2", "skip"] do
+        comments: ["depth 3", "all", "suppress_if"],
+        comments_exclude: ["any", "depth 2"] do
         defmodule Module do
           def foo, do: :ok
         end
       end
 
       test_exercise_analysis "has :error, and :ok at depth 3",
-        comments: ["meta", "depth 2"],
-        comments_exclude: ["any", "all", "depth 3", "skip", "suppress_if"] do
+        comments: ["depth 2"],
+        comments_exclude: ["any", "all", "depth 3", "suppress_if"] do
         defmodule Module do
           defmodule SubModule do
             def foo, do: :ok
@@ -547,8 +529,7 @@ defmodule ElixirAnalyzer.ExerciseTest.FeatureTest do
       end
 
       test_exercise_analysis "empty",
-        comments: ["meta", "depth 2", "depth 3", "any", "all", "suppress_if"],
-        comments_exclude: ["skip"] do
+        comments: ["depth 2", "depth 3", "any", "all", "suppress_if"] do
         defmodule Module do
         end
       end
@@ -557,7 +538,7 @@ defmodule ElixirAnalyzer.ExerciseTest.FeatureTest do
 
   describe "incorrect use raises errors" do
     unsupported =
-      "Unsupported expression `unsupported`.\nThe macro `feature` supports expressions: comment, type, find, status, suppress_if, depth, meta, form.\n"
+      "Unsupported expression `unsupported`.\nThe macro `feature` supports expressions: comment, type, find, suppress_if, depth, form.\n"
 
     assert_raise RuntimeError, unsupported, fn ->
       defmodule Failure do


### PR DESCRIPTION
In this PR, I removed all mentions of `status` and `meta` from `feature`.

Keeping the metadata from the solutions would make the solution whitespace dependent, and skipping test was probably only useful during early development. 

Both of these were completely unused. 