### PR TITLE
Update `boutique-inventory` exemplar in tests

### DIFF
--- a/test/elixir_analyzer/test_suite/boutique_inventory_test.exs
+++ b/test/elixir_analyzer/test_suite/boutique_inventory_test.exs
@@ -13,11 +13,16 @@ defmodule ElixirAnalyzer.ExerciseTest.BoutiqueInventoryTest do
         Enum.filter(inventory, fn item -> Map.get(item, :price) == nil end)
       end
 
+      def update_names(inventory, old_word, new_word) do
+        Enum.map(inventory, fn item ->
+          Map.update!(item, :name, fn name -> String.replace(name, old_word, new_word) end)
+        end)
+      end
+
       def increase_quantity(item, count) do
         Map.update(item, :quantity_by_size, %{}, fn quantity_by_size ->
           quantity_by_size
-          |> Enum.map(fn {size, quantity} -> {size, quantity + count} end)
-          |> Enum.into(%{})
+          |> Map.new(fn {size, quantity} -> {size, quantity + count} end)
         end)
       end
 


### PR DESCRIPTION
I accidentally merged a dependabot PR that ended up failing the tests because the `boutique-inventory` exemplar was updated in `elixir`.

This is a quick fix to address my mistake, but feel free to add the new analyzer checks on top.