### PR TITLE
Extend local calls to match when referencing the current module by name or __MODULE__

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -8,6 +8,8 @@ assert_call "description" do
 end
 ```
 
+This will also find local calls that reference the module by name or by `__MODULE__`.
+
 ## Find function call by module name and function name (any arity, any argument names)
 
 ```elixir

--- a/test/elixir_analyzer/exercise_test/assert_call/indirect_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call/indirect_call_test.exs
@@ -66,6 +66,24 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.IndirectCallTest do
           final_function(:math.pi())
         end
       end,
+      # via two helpers unnecessarily referencing the module in local calls
+      defmodule AssertCallVerification do
+        def main_function() do
+          AssertCallVerification.helper("")
+          |> do_something()
+        end
+
+        def helper(path) do
+          __MODULE__.helper_2(path)
+        end
+
+        def helper_2(path) do
+          Elixir.Mix.Utils.read_path(path)
+
+          :math.pi()
+          |> AssertCallVerification.final_function()
+        end
+      end,
       # Full path for the helper function
       defmodule AssertCallVerification do
         def main_function() do
@@ -200,7 +218,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.IndirectCallTest do
       end,
       defmodule AssertCallVerification do
         # Internal modules don't fool assert_call
-        defmodule UnrelateInternaldModule do
+        defmodule UnrelatedInternalModule do
           def main_function() do
             helper("")
             |> do_something()

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -88,6 +88,178 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
     end
   end
 
+  test_exercise_analysis "finds local calls if they use the module name to reference the function",
+                         comments: [] do
+    [
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = AssertCallVerification.helper()
+          IO.puts(result)
+
+          AssertCallVerification.private_helper() |> IO.puts()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      # call helper with capture notation
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = Enum.map(result, &AssertCallVerification.helper/0)
+          IO.puts(result)
+
+          private_helper() |> IO.puts()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      # indirect call
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = AssertCallVerification.extra_helper()
+          IO.puts(result)
+
+          AssertCallVerification.private_helper() |> IO.puts()
+        end
+
+        def extra_helper() do
+          AssertCallVerification.helper()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+    ]
+  end
+
+  test_exercise_analysis "finds local calls if they use __MODULE__ to reference the function",
+                         comments: [] do
+    [
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = __MODULE__.helper()
+          IO.puts(result)
+
+          __MODULE__.private_helper() |> IO.puts()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      # call helper with capture notation
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = Enum.map(result, &__MODULE__.helper/0)
+          IO.puts(result)
+
+          private_helper() |> IO.puts()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      # indirect call
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = __MODULE__.extra_helper()
+          IO.puts(result)
+
+          __MODULE__.private_helper() |> IO.puts()
+        end
+
+        def extra_helper() do
+          __MODULE__.helper()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+    ]
+  end
+
+  test_exercise_analysis "doesn't find local calls if they're same-named functions from a different module",
+                         comments: [
+                           "didn't find a local call to helper/0",
+                           "didn't find a local call to helper/0 within function/0",
+                           "didn't find a local call to private_helper/0",
+                           "didn't find a local call to private_helper/0 within function/0"
+                         ] do
+    [
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = OtherModule.helper()
+          IO.puts(result)
+
+          OtherModule.private_helper() |> IO.puts()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      # call helper with capture notation
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = Enum.map(result, &OtherModule.helper/0)
+          IO.puts(result)
+
+          OtherModule.private_helper() |> IO.puts()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end
+    ]
+  end
+
   test_exercise_analysis "missing call to IO.puts/1 in solution",
     comments: [
       "didn't find a call to IO.puts/1 anywhere in solution",

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -89,7 +89,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
   end
 
   test_exercise_analysis "finds local calls if they use the module name to reference the function",
-                         comments: [] do
+    comments: [] do
     [
       defmodule AssertCallVerification do
         def function() do
@@ -147,12 +147,12 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
         defp private_helper do
           :privately_helped
         end
-      end,
+      end
     ]
   end
 
   test_exercise_analysis "finds local calls if they use __MODULE__ to reference the function",
-                         comments: [] do
+    comments: [] do
     [
       defmodule AssertCallVerification do
         def function() do
@@ -190,6 +190,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
         end
       end,
       # indirect call
+      # TODO: move to other test file
       defmodule AssertCallVerification do
         def function() do
           x = List.first([1, 2, 3])
@@ -210,17 +211,17 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
         defp private_helper do
           :privately_helped
         end
-      end,
+      end
     ]
   end
 
   test_exercise_analysis "doesn't find local calls if they're same-named functions from a different module",
-                         comments: [
-                           "didn't find a local call to helper/0",
-                           "didn't find a local call to helper/0 within function/0",
-                           "didn't find a local call to private_helper/0",
-                           "didn't find a local call to private_helper/0 within function/0"
-                         ] do
+    comments: [
+      "didn't find a local call to helper/0",
+      "didn't find a local call to helper/0 within function/0",
+      "didn't find a local call to private_helper/0",
+      "didn't find a local call to private_helper/0 within function/0"
+    ] do
     [
       defmodule AssertCallVerification do
         def function() do

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -190,7 +190,6 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
         end
       end,
       # indirect call
-      # TODO: move to other test file
       defmodule AssertCallVerification do
         def function() do
           x = List.first([1, 2, 3])

--- a/test/elixir_analyzer/exercise_test/assert_no_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_no_call_test.exs
@@ -22,20 +22,50 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertNoCallTest do
 
   test_exercise_analysis "found a local call to helper function",
     comments: ["found a local call to helper/0"] do
-    defmodule AssertNoCallVerification do
-      def function() do
-        helper() |> IO.puts()
-        private_helper()
-      end
+    [
+      defmodule AssertNoCallVerification do
+        def function() do
+          helper() |> IO.puts()
+          private_helper()
+        end
 
-      def helper do
-        :helped
-      end
+        def helper do
+          :helped
+        end
 
-      defp private_helper do
-        :privately_helped
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      defmodule AssertNoCallVerification do
+        def function() do
+          helper() |> IO.puts()
+          AssertNoCallVerification.private_helper()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end,
+      defmodule AssertNoCallVerification do
+        def function() do
+          helper() |> IO.puts()
+          __MODULE__.private_helper()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
       end
-    end
+    ]
   end
 
   test_exercise_analysis "found a local call to from specific function",

--- a/test/elixir_analyzer/test_suite/lasagna_test.exs
+++ b/test/elixir_analyzer/test_suite/lasagna_test.exs
@@ -31,27 +31,50 @@ defmodule ElixirAnalyzer.TestSuite.LasagnaTest do
 
   test_exercise_analysis "other reasonable solution",
     comments: [] do
-    defmodule Lasagna do
-      def expected_minutes_in_oven() do
-        40
-      end
+    [
+      defmodule Lasagna do
+        def expected_minutes_in_oven() do
+          40
+        end
 
-      def remaining_minutes_in_oven(actual) do
-        expected_minutes_in_oven() - actual
-      end
+        def remaining_minutes_in_oven(actual) do
+          expected_minutes_in_oven() - actual
+        end
 
-      def preparation_time_in_minutes(layers) do
-        2 * layers
-      end
+        def preparation_time_in_minutes(layers) do
+          2 * layers
+        end
 
-      def total_time_in_minutes(layers, actual) do
-        actual + preparation_time_in_minutes(layers)
-      end
+        def total_time_in_minutes(layers, actual) do
+          actual + preparation_time_in_minutes(layers)
+        end
 
-      def alarm() do
-        "Ding!"
+        def alarm() do
+          "Ding!"
+        end
+      end,
+      defmodule Lasagna do
+        def expected_minutes_in_oven() do
+          40
+        end
+
+        def remaining_minutes_in_oven(actual) do
+          Lasagna.expected_minutes_in_oven() - actual
+        end
+
+        def preparation_time_in_minutes(layers) do
+          2 * layers
+        end
+
+        def total_time_in_minutes(layers, actual) do
+          actual + __MODULE__.preparation_time_in_minutes(layers)
+        end
+
+        def alarm() do
+          "Ding!"
+        end
       end
-    end
+    ]
   end
 
   describe "function reuse" do


### PR DESCRIPTION
Resolves https://github.com/exercism/elixir-analyzer/issues/267