### PR TITLE
Add exception `%{}` to function capture common check

### DIFF
--- a/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_capture.ex
@@ -41,7 +41,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCapture do
 
   defp annotate(node, acc), do: {node, acc}
 
-  @exceptions [:<<>>, :{}]
+  @exceptions [:<<>>, :{}, :%{}]
   defp find_anonymous(
          {:&, _, [{name, _, args}]} = node,
          %{capture_depth: depth, functions: functions}

--- a/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_capture_test.exs
@@ -48,6 +48,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionCaptureTest do
             |> Enum.map(fn x -> <<x>> end)
             |> Enum.reduce([], fn a, b, c -> {a, b, c} end)
             |> Enum.reduce([], &{&1, &2, &2})
+            |> Enum.map(fn -> %{} end)
           end
 
           # https://github.com/exercism/elixir/blob/main/exercises/practice/sgf-parsing/.meta/example.ex


### PR DESCRIPTION
Closes #282.