### PR TITLE
Add permission to update git submodule on CI

### DIFF
--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Update submodules
         run: |
+          git config --global --add safe.directory /__w/elixir-analyzer/elixir-analyzer
           git submodule update --recursive --remote
 
       - name: Install Dependencies

--- a/.github/workflows/elixir_test_external.yml
+++ b/.github/workflows/elixir_test_external.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Update submodules
         run: |
+          git config --global --add safe.directory /__w/elixir-analyzer/elixir-analyzer
           git submodule update --recursive --remote
 
       - name: Install Dependencies

--- a/test/elixir_analyzer/test_suite/language_list_test.exs
+++ b/test/elixir_analyzer/test_suite/language_list_test.exs
@@ -15,7 +15,7 @@ defmodule ElixirAnalyzer.ExerciseTest.LanguageListTest do
 
       def count(list), do: length(list)
 
-      def exciting_list?(list), do: "Elixir" in list
+      def functional_list?(list), do: "Elixir" in list
     end
   end
 
@@ -53,22 +53,22 @@ defmodule ElixirAnalyzer.ExerciseTest.LanguageListTest do
         def count(list), do: E.count(list)
       end,
       defmodule LanguageList do
-        def exciting_list?(list), do: Enum.any?(list, &(&1 == "Elixir"))
+        def functional_list?(list), do: Enum.any?(list, &(&1 == "Elixir"))
       end,
       defmodule LanguageList do
-        def exciting_list?(list), do: Enum.filter(list, &(&1 == "Elixir")) != []
+        def functional_list?(list), do: Enum.filter(list, &(&1 == "Elixir")) != []
       end,
       defmodule LanguageList do
         import Enum
-        def exciting_list?(list), do: any?(list, &(&1 == "Elixir"))
+        def functional_list?(list), do: any?(list, &(&1 == "Elixir"))
       end,
       defmodule LanguageList do
         import Enum, only: [any?: 2]
-        def exciting_list?(list), do: any?(list, &(&1 == "Elixir"))
+        def functional_list?(list), do: any?(list, &(&1 == "Elixir"))
       end,
       defmodule LanguageList do
         alias Enum, as: E
-        def exciting_list?(list), do: E.any?(list, &(&1 == "Elixir"))
+        def functional_list?(list), do: E.any?(list, &(&1 == "Elixir"))
       end
     ]
   end

--- a/test/elixir_analyzer/test_suite/take_a_number_deluxe_test.exs
+++ b/test/elixir_analyzer/test_suite/take_a_number_deluxe_test.exs
@@ -89,8 +89,8 @@ defmodule ElixirAnalyzer.TestSuite.TakeANumberDeluxeTest do
       end
 
       @impl GenServer
-      def handle_info(:timeout, _state) do
-        exit(:normal)
+      def handle_info(:timeout, state) do
+        {:stop, :normal, state}
       end
 
       @impl GenServer


### PR DESCRIPTION
[This commit](https://github.com/actions/checkout/commit/dcd71f646680f2efd8db4afa5ad64fdcba30e748) in the update of actions/checkout to 3.0.1 locked the repository and therefore we could not update the git submodule.

The error message suggested a fix for this, so I updated the CI accordingly, and it seems to work.

Unrelated to this, I updated the solutions of two concept exercises since they changed on `elixir` and also updated the submodule. 