### PR TITLE
Bug fixes and improvements to function annotation order common check

### DIFF
--- a/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
@@ -9,7 +9,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
   Common check to be run on every single solution.
   """
 
-  @def_ops [:def, :defp, :defmacro, :defmacrop, :defguard, :defguardp]
+  @def_ops [:def, :defmacro]
 
   def run(ast) do
     acc = %{module: [], definitions: %{}}
@@ -124,9 +124,13 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
     Enum.uniq(operations) not in [
       [],
       [:def],
+      [:defmacro],
       [:spec, :def],
+      [:spec, :defmacro],
       [:doc, :def],
-      [:doc, :spec, :def]
+      [:doc, :defmacro],
+      [:doc, :spec, :def],
+      [:doc, :spec, :defmacro]
     ]
   end
 end

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
@@ -12,7 +12,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
   @def_ops [:def, :defmacro]
 
   def run(ast) do
-    acc = %{module: [], definitions: %{}}
+    acc = %{module: [], definitions: %{[] => []}}
     {_, %{definitions: definitions}} = Macro.traverse(ast, acc, &enter_node/2, &exit_node/2)
 
     definitions

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
@@ -52,27 +52,6 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
     {ast, acc}
   end
 
-  defp check_errors(attrs) do
-    Enum.reduce(attrs, [], &check_wrong_order/2)
-  end
-
-  defp check_wrong_order(attr, acc) do
-    case attr.operations do
-      [:spec, :doc | _] ->
-        [order_error_msg()]
-
-      [hd | tl] when hd in @def_ops ->
-        if :spec in tl or :doc in tl do
-          [order_error_msg()]
-        else
-          acc
-        end
-
-      _ ->
-        acc
-    end
-  end
-
   defp chunk_definitions(definitions) do
     chunk_fun = fn
       {:context, context}, %{context: nil} = chunk ->
@@ -133,6 +112,27 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
 
   defp do_merge_definitions([], acc) do
     Enum.reverse(acc)
+  end
+
+  defp check_errors(attrs) do
+    Enum.reduce(attrs, [], &check_wrong_order/2)
+  end
+
+  defp check_wrong_order(attr, acc) do
+    case attr.operations do
+      [:spec, :doc | _] ->
+        [order_error_msg()]
+
+      [hd | tl] when hd in @def_ops ->
+        if :spec in tl or :doc in tl do
+          [order_error_msg()]
+        else
+          acc
+        end
+
+      _ ->
+        acc
+    end
   end
 
   defp order_error_msg() do

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
@@ -21,9 +21,9 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
     |> check_errors()
   end
 
-  defp traverse({:defmodule, _, [{:__aliases__, _, aliases}, [do: do_block]]}, acc) do
+  defp traverse({:defmodule, _, [{:__aliases__, _, aliases}, _]} = ast, acc) do
     context = {:context, Module.concat(aliases)}
-    {do_block, [context | acc]}
+    {ast, [context | acc]}
   end
 
   defp traverse({:@, _meta, [{:spec, _, [{:"::", _, [{fn_name, _, _} | _]}]} | _]} = ast, acc) do

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
@@ -58,7 +58,8 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
         {:cont, %{chunk | context: context}}
 
       {:context, context}, %{context: _} = chunk ->
-        {:cont, chunk, %{context: context, name: nil, operations: []}}
+        {:cont, %{chunk | operations: Enum.reverse(chunk.operations)},
+         %{context: context, name: nil, operations: []}}
 
       {op, name}, %{name: name, operations: ops} = chunk ->
         {:cont, %{chunk | operations: [op | ops]}}

--- a/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
@@ -150,7 +150,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrderTest d
     comments: [] do
     [
       defmodule Test do
-        @spec is_one(integer()) :: integer()
+        @spec one?(integer()) :: integer()
         def one?(1), do: true
         def one?(2), do: false
         def one?(3), do: false
@@ -164,7 +164,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrderTest d
     comments: [] do
     [
       defmodule Test do
-        @spec is_one(number)
+        @spec one?(number)
         def one?(number), do: number == 1
       end
     ]
@@ -255,6 +255,46 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrderTest d
       defmodule Test do
         def test(x), do: x
         @doc "just a test function"
+      end
+    ]
+  end
+
+  test_exercise_analysis "overloading specifications is ok",
+    comments: [] do
+    [
+      defmodule Test do
+        @doc "https://hexdocs.pm/elixir/typespecs.html#defining-a-specification"
+        @spec function(integer) :: atom
+        @spec function(atom) :: integer
+        def function(1), do: :one
+        def function(:one), do: 1
+      end
+    ]
+  end
+
+  test_exercise_analysis "doc between overloading specifications should crash",
+    comments: [Constants.solution_function_annotation_order()] do
+    [
+      defmodule Test do
+        @spec function(integer) :: atom
+        @doc "https://hexdocs.pm/elixir/typespecs.html#defining-a-specification"
+        @spec function(atom) :: integer
+        def function(1), do: :one
+        def function(:one), do: 1
+      end,
+      defmodule Test do
+        @spec function(integer) :: atom
+        @spec function(atom) :: integer
+        @doc "https://hexdocs.pm/elixir/typespecs.html#defining-a-specification"
+        def function(1), do: :one
+        def function(:one), do: 1
+      end,
+      defmodule Test do
+        @spec function(integer) :: atom
+        @spec function(atom) :: integer
+        def function(1), do: :one
+        @doc "https://hexdocs.pm/elixir/typespecs.html#defining-a-specification"
+        def function(:one), do: 1
       end
     ]
   end

--- a/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
@@ -397,4 +397,13 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrderTest d
       end
     ]
   end
+
+  test_exercise_analysis "can handle test snippets without module definition",
+    comments: [] do
+    [
+      def function() do
+        :ok
+      end
+    ]
+  end
 end

--- a/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
@@ -279,6 +279,23 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrderTest d
           def x(), do: 1
         end
       end,
+      defmodule Main do
+        defmodule Sub do
+          def y(), do: 0
+          def x(), do: 1
+        end
+
+        @spec x() :: integer()
+        def x(), do: 2
+      end,
+      defmodule Main do
+        defmodule Sub do
+          def x(), do: 1
+        end
+
+        @spec x() :: integer()
+        def x(), do: 2
+      end,
       # chriseyre2000's solution to grade-school
       defmodule School do
         @moduledoc """

--- a/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
@@ -278,6 +278,69 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrderTest d
           @doc ""
           def x(), do: 1
         end
+      end,
+      # chriseyre2000's solution to grade-school
+      defmodule School do
+        @moduledoc """
+        Simulate students in a school.
+
+        Each student is in a grade.
+        """
+        @type school :: any()
+        @doc """
+        Create a new, empty school.
+        """
+        @spec new() :: school
+        def new() do
+          %{}
+        end
+
+        @doc """
+        Add a student to a particular grade in school.
+        """
+        @spec add(school, String.t(), integer) :: {:ok | :error, school}
+        def add(school, name, grade) do
+          if school |> Map.get(name) != nil do
+            {:error, school}
+          else
+            {:ok, school |> Map.put(name, grade)}
+          end
+        end
+
+        @doc """
+        Return the names of the students in a particular grade, sorted alphabetically.
+        """
+        @spec grade(school, integer) :: [String.t()]
+        def grade(school, grade) do
+          for({k, v} <- school, v == grade, do: k) |> Enum.sort()
+        end
+
+        @doc """
+        Return the names of all the students in the school sorted by grade and name.
+        """
+        @spec roster(school) :: [String.t()]
+        def roster(school) do
+          for({k, v} <- school, do: {k, v})
+          |> Enum.sort(School.Sorting)
+          |> Enum.map(&elem(&1, 0))
+        end
+
+        defmodule Sorting do
+          @doc """
+          Provides a compare function
+          """
+          @spec compare(first :: {String.t(), integer}, second :: {String.t(), integer}) ::
+                  :gt | :lt | :eq
+          def compare({name, grade}, {name2, grade2}) do
+            cond do
+              grade > grade2 -> :gt
+              grade < grade2 -> :lt
+              name > name2 -> :gt
+              name < name2 -> :lt
+              true -> :eq
+            end
+          end
+        end
       end
     ]
   end

--- a/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/function_annotation_order_test.exs
@@ -17,7 +17,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrderTest d
     end
   end
 
-  test_exercise_analysis "works for def, defp, defmacro, defmacrop, defguard, and defguardp",
+  test_exercise_analysis "works for def and defmacro",
     comments: [Constants.solution_function_annotation_order()] do
     [
       defmodule Test do
@@ -28,27 +28,23 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrderTest d
       defmodule Test do
         @spec x()
         @doc ""
-        defp x()
-      end,
-      defmodule Test do
-        @spec x()
-        @doc ""
         defmacro x()
+      end
+    ]
+  end
+
+  test_exercise_analysis "correct order for def and defmacro is ok",
+    comments: [] do
+    [
+      defmodule Test do
+        @doc ""
+        @spec x()
+        def x()
       end,
       defmodule Test do
-        @spec x()
         @doc ""
-        defmacrop x()
-      end,
-      defmodule Test do
         @spec x()
-        @doc ""
-        defguard x()
-      end,
-      defmodule Test do
-        @spec x()
-        @doc ""
-        defguardp x()
+        defmacro x()
       end
     ]
   end


### PR DESCRIPTION
Closes #284.

The bug fix for #284 was quite simple, but I kept going, because I wasn't totally satisfied with the quality of this common check. 

I ended up modifying the code a lot, but I made sure to always add failing tests before working on a feature, so I recommend going through it commit by commit to keep track of the context. 

In a nutshell, here are some issues that this PR fixes:
- List of definition was not getting reversed at transition between modules/submodules (bug in #284)
- AST traversal changed the AST, causing to skip modules with a single function
- AST traversal didn't handle transitions between modules/submodules correctly
- code didn't handle overloaded specs
- code handled private functions/macros and guards, which are not supposed to have public docs and specs (I guess)
- there were other issues due to my own modifications that I fixed at the end
