### PR TITLE
Remove 'no explicit nil handling feedback' from basketball_website

### DIFF
--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -46,7 +46,6 @@ defmodule ElixirAnalyzer.Constants do
     # Concept exercises
 
     # Basketball Website comments
-    basketball_website_no_explicit_nil: "elixir.basketball-website.no_explicit_nil",
     basketball_website_no_map: "elixir.basketball-website.no_map",
     basketball_website_get_in: "elixir.basketball-website.get_in",
 

--- a/lib/elixir_analyzer/test_suite/basketball_website.ex
+++ b/lib/elixir_analyzer/test_suite/basketball_website.ex
@@ -2,16 +2,6 @@ defmodule ElixirAnalyzer.TestSuite.BasketballWebsite do
   alias ElixirAnalyzer.Constants
   use ElixirAnalyzer.ExerciseTest
 
-  feature "does not handle nil explicitly" do
-    type :actionable
-    find :none
-    comment Constants.basketball_website_no_explicit_nil()
-
-    form do
-      nil
-    end
-  end
-
   assert_no_call "does not use Map" do
     type :essential
     comment Constants.basketball_website_no_map()

--- a/test/elixir_analyzer/test_suite/basketball_website_test.exs
+++ b/test/elixir_analyzer/test_suite/basketball_website_test.exs
@@ -59,7 +59,7 @@ defmodule ElixirAnalyzer.ExerciseTest.BasketballWebsiteTest do
 
   describe "using Map" do
     test_exercise_analysis "there should be no usage of the map module",
-      comments_include: [ElixirAnalyzer.Constants.basketball_website_no_explicit_nil()] do
+      comments_include: [ElixirAnalyzer.Constants.basketball_website_no_map()] do
       defmodule BasketballWebsite do
         def extract_from_path(data, path) do
           paths = String.split(path, ".", trim: true)

--- a/test/elixir_analyzer/test_suite/basketball_website_test.exs
+++ b/test/elixir_analyzer/test_suite/basketball_website_test.exs
@@ -57,25 +57,6 @@ defmodule ElixirAnalyzer.ExerciseTest.BasketballWebsiteTest do
     end
   end
 
-  describe "explicit nil" do
-    test_exercise_analysis "there should be no explicit nil handling",
-      comments_include: [ElixirAnalyzer.Constants.basketball_website_no_explicit_nil()] do
-      defmodule BasketballWebsite do
-        def extract_from_path(data, path) do
-          paths = String.split(path, ".", trim: true)
-          do_extract(data, paths)
-        end
-
-        defp do_extract(nil, _), do: nil
-        defp do_extract(data, []), do: data
-
-        defp do_extract(data, [path | next]) do
-          do_extract(data[path], next)
-        end
-      end
-    end
-  end
-
   describe "using Map" do
     test_exercise_analysis "there should be no usage of the map module",
       comments_include: [ElixirAnalyzer.Constants.basketball_website_no_explicit_nil()] do


### PR DESCRIPTION
As we discussed this [issue](https://github.com/exercism/elixir-analyzer/issues/305), I have just removed `nil case feedback` from the basketball_website analyzer.

Resolves https://github.com/exercism/elixir-analyzer/issues/305