### PR TITLE
fixed issue #318, order of @doc and @spec in private functions or macros

### DIFF
--- a/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
@@ -21,52 +21,52 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
     |> check_errors()
   end
 
-  def enter_node({:defmodule, _, [{:__aliases__, _, aliases}, _]} = ast, acc) do
+  defp enter_node({:defmodule, _, [{:__aliases__, _, aliases}, _]} = ast, acc) do
     module = [aliases | acc.module]
     definitions = Map.put(acc.definitions, module, [])
     {ast, %{module: module, definitions: definitions}}
   end
 
-  def enter_node({:@, _, [{:spec, _, [{:"::", _, [{fn_name, _, _} | _]}]} | _]} = ast, acc) do
+  defp enter_node({:@, _, [{:spec, _, [{:"::", _, [{fn_name, _, _} | _]}]} | _]} = ast, acc) do
     definitions = Map.update!(acc.definitions, acc.module, &[{:spec, fn_name} | &1])
     {ast, %{acc | definitions: definitions}}
   end
 
-  def enter_node({:@, _, [{:spec, _, [{fn_name, _, _}]}]} = ast, acc) do
+  defp enter_node({:@, _, [{:spec, _, [{fn_name, _, _}]}]} = ast, acc) do
     definitions = Map.update!(acc.definitions, acc.module, &[{:spec, fn_name} | &1])
     {ast, %{acc | definitions: definitions}}
   end
 
-  def enter_node({:@, _, [{:doc, _, _}]} = ast, acc) do
+  defp enter_node({:@, _, [{:doc, _, _}]} = ast, acc) do
     definitions = Map.update!(acc.definitions, acc.module, &[:doc | &1])
     {ast, %{acc | definitions: definitions}}
   end
 
-  def enter_node({op, _, [{:when, _, [{fn_name, _, _} | _]} | _]} = ast, acc)
+  defp enter_node({op, _, [{:when, _, [{fn_name, _, _} | _]} | _]} = ast, acc)
        when op in @def_ops do
     definitions = Map.update!(acc.definitions, acc.module, &[{op, fn_name} | &1])
     {ast, %{acc | definitions: definitions}}
   end
 
-  def enter_node({op, _, [{fn_name, _, _} | _]} = ast, acc)
+  defp enter_node({op, _, [{fn_name, _, _} | _]} = ast, acc)
        when op in @def_ops do
     definitions = Map.update!(acc.definitions, acc.module, &[{op, fn_name} | &1])
     {ast, %{acc | definitions: definitions}}
   end
 
-  def enter_node(ast, acc) do
+  defp enter_node(ast, acc) do
     {ast, acc}
   end
 
-  def exit_node({:defmodule, _, _} = ast, %{module: module} = acc) do
+  defp exit_node({:defmodule, _, _} = ast, %{module: module} = acc) do
     {ast, %{acc | module: tl(module)}}
   end
 
-  def exit_node(ast, acc) do
+  defp exit_node(ast, acc) do
     {ast, acc}
   end
 
-  def chunk_definitions(definitions) do
+  defp chunk_definitions(definitions) do
     chunk_fun = fn
       {op, name}, %{name: nil, operations: ops} = chunk ->
         {:cont, %{chunk | name: name, operations: [op | ops]}}
@@ -89,7 +89,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
     )
   end
 
-  def merge_definitions(definitions) do
+  defp merge_definitions(definitions) do
     Enum.reduce(
       definitions,
       [],
@@ -104,7 +104,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
     )
   end
 
-  def check_errors(attrs) do
+  defp check_errors(attrs) do
     if Enum.any?(attrs, &check_wrong_order/1) do
       [
         {:fail,
@@ -119,7 +119,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
     end
   end
 
-  def check_wrong_order(%{operations: operations}) do
+  defp check_wrong_order(%{operations: operations}) do
     Enum.uniq(operations) not in [
       [],
       [:doc], # first three cases allow for private functions (:def) or macros (:defmacrop) to have a doc, a spec or a doc-spec in the right order

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
@@ -8,17 +8,13 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
 
   Common check to be run on every single solution.
   """
-
   @def_ops [:def, :defmacro]
 
   def run(ast) do
     acc = %{module: [], definitions: %{[] => []}}
     {_, %{definitions: definitions}} = Macro.traverse(ast, acc, &enter_node/2, &exit_node/2)
 
-    definitions
-    |> Enum.flat_map(fn {_module, ops} ->
-      ops |> Enum.reverse() |> chunk_definitions() |> merge_definitions()
-    end)
+    definitions |> Enum.flat_map(fn {_module, ops} ->  ops |> Enum.reverse() |> chunk_definitions() |> merge_definitions()  end)
     |> check_errors()
   end
 
@@ -123,6 +119,9 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
   defp check_wrong_order(%{operations: operations}) do
     Enum.uniq(operations) not in [
       [],
+      [:doc], # first three cases allow for private functions (:defp) or macros (:defmacrop) to have a doc, a spec or a doc-spec in the right order
+      [:spec],
+      [:doc, :spec],
       [:def],
       [:defmacro],
       [:spec, :def],

--- a/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/function_annotation_order.ex
@@ -14,7 +14,10 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.FunctionAnnotationOrder do
     acc = %{module: [], definitions: %{[] => []}}
     {_, %{definitions: definitions}} = Macro.traverse(ast, acc, &enter_node/2, &exit_node/2)
 
-    definitions |> Enum.flat_map(fn {_module, ops} ->  ops |> Enum.reverse() |> chunk_definitions() |> merge_definitions()  end)
+    definitions
+    |> Enum.flat_map(fn {_module, ops} ->
+      ops |> Enum.reverse() |> chunk_definitions() |> merge_definitions()
+    end)
     |> check_errors()
   end
 


### PR DESCRIPTION
By just adding three lines in the `check_wrong_order()` function, one is able to allow for all combinations with `:defp` and `:defmacrop` at once. Since the nodes corresponding to different functions are chunked and merged accordingly, there is no harm done by adding these to the allowed combinations. 
The three examples from Angelika that produced comments before now run smoothly. 
A wrong order of `@spec - @doc - def(p)/defmacro(p)` still doesn't pass. 
`mix test` also passes completely.

I think one may leave out the `@def_ops` completely, such that the `check_wrong_order()` function just reads something like
```elixir
defp check_wrong_order(%{operations: operations}) do
    Enum.uniq(operations) not in [
      [],
      [:spec],
      [:doc],
      [:doc, :spec],
    ]
  end
end
```
but I didn't try it.

I'm not sure if I should write corresponding tests for the new behaviour and if so, in which file I should do that. 
What's your opinion?