### PR TITLE
Allow Kernel functions to be called with or without module in `assert_call`

### DIFF
--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -224,7 +224,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
 
   # No module path in AST
   def matching_function_call?(function, {module_path, search_name}, modules, _in_module) do
-    {name, arg_number} =
+    {name, arity} =
       case function do
         {:&, _, [{:/, _, [{name, _, name_args}, arity]}]}
         when is_atom(name) and is_atom(name_args) and is_integer(arity) and
@@ -238,17 +238,20 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
           {nil, 0}
       end
 
-    case modules[List.wrap(module_path)] do
+    function_imported?(module_path, name, arity, modules)
+  end
+
+  def matching_function_call?(_, _, _, _), do: false
+
+  defp function_imported?(module, name, arity, modules) do
+    case modules[List.wrap(module)] do
       nil ->
         false
 
       imported ->
-        {name, arg_number} in imported or
-          {String.to_atom("MACRO-#{name}"), arg_number + 1} in imported
+        {name, arity} in imported or {String.to_atom("MACRO-#{name}"), arity + 1} in imported
     end
   end
-
-  def matching_function_call?(_, _, _, _), do: false
 
   @doc """
   node is a module definition

--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -180,6 +180,10 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
       {^search_name, _, _args} ->
         true
 
+      # Kernel functions
+      {{:., _, [{:__aliases__, _, [:Kernel]}, ^search_name]}, _, _args} ->
+        true
+
       # local calls that unnecessarily reference the module by name
       {{:., _, [{:__aliases__, _, _}, ^search_name]}, _, _args} ->
         matching_function_call?(function, {in_module, search_name}, modules, in_module)
@@ -219,13 +223,28 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
   end
 
   # No module path in AST
-  def matching_function_call?({name, meta, args}, {module_path, search_name}, modules, _in_module)
-      when is_list(args) and search_name in [:_, name] do
-    arg_number = length(args) + Keyword.get(meta, :extra_arg, 0)
+  def matching_function_call?(function, {module_path, search_name}, modules, _in_module) do
+    {name, arg_number} =
+      case function do
+        {:&, _, [{:/, _, [{name, _, name_args}, arity]}]}
+        when is_atom(name) and is_atom(name_args) and is_integer(arity) and
+               search_name in [name, :_] ->
+          {name, arity}
+
+        {name, meta, args} when is_atom(name) and is_list(args) and search_name in [name, :_] ->
+          {name, length(args) + Keyword.get(meta, :extra_arg, 0)}
+
+        _ ->
+          {nil, 0}
+      end
 
     case modules[List.wrap(module_path)] do
-      nil -> false
-      imported -> {name, arg_number} in imported
+      nil ->
+        false
+
+      imported ->
+        {name, arg_number} in imported or
+          {String.to_atom("MACRO-#{name}"), arg_number + 1} in imported
     end
   end
 

--- a/lib/elixir_analyzer/test_suite/rpn_calculator_inspection.ex
+++ b/lib/elixir_analyzer/test_suite/rpn_calculator_inspection.ex
@@ -21,7 +21,7 @@ defmodule ElixirAnalyzer.TestSuite.RpnCalculatorInspection do
 
   assert_call "calls spawn_link" do
     type :essential
-    called_fn name: :spawn_link
+    called_fn module: Kernel, name: :spawn_link
     comment Constants.rpn_calculator_inspection_use_start_link()
     suppress_if "calls Task.start_link", :pass
   end

--- a/lib/elixir_analyzer/test_suite/rpn_calculator_inspection.ex
+++ b/lib/elixir_analyzer/test_suite/rpn_calculator_inspection.ex
@@ -21,7 +21,7 @@ defmodule ElixirAnalyzer.TestSuite.RpnCalculatorInspection do
 
   assert_call "calls spawn_link" do
     type :essential
-    called_fn module: Kernel, name: :spawn_link
+    called_fn name: :spawn_link
     comment Constants.rpn_calculator_inspection_use_start_link()
     suppress_if "calls Task.start_link", :pass
   end

--- a/test/elixir_analyzer/exercise_test/assert_call/kernel_functions_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call/kernel_functions_test.exs
@@ -1,0 +1,65 @@
+defmodule ElixirAnalyzer.ExerciseTest.AssertCall.KernelTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.Support.AnalyzerVerification.AssertCall.Kernel
+
+  test_exercise_analysis "Not calling anything",
+    comments: [
+      "didn't find a call to Kernel.dbg/0",
+      "didn't find a call to dbg/0",
+      "didn't find a call to Kernel.self/0",
+      "didn't find a call to self/0"
+    ] do
+    defmodule AssertCallVerification do
+      def function() do
+        :ok
+      end
+    end
+  end
+
+  test_exercise_analysis "Calling dbg/0",
+    comments_exclude: ["didn't find a call to Kernel.dbg/0", "didn't find a call to dbg/0"] do
+    [
+      defmodule AssertCallVerification do
+        def function() do
+          Kernel.dbg()
+        end
+      end,
+      defmodule AssertCallVerification do
+        def function() do
+          dbg()
+        end
+      end,
+      defmodule AssertCallVerification do
+        def function() do
+          &Kernel.dbg/0
+        end
+      end,
+      defmodule AssertCallVerification do
+        def function() do
+          &dbg/0
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "Calling self/0",
+    comments_exclude: ["didn't find a call to Kernel.self/0", "didn't find a call to self/0"] do
+    [
+      defmodule AssertCallVerification do
+        def function() do
+          Kernel.self()
+        end
+      end,
+      defmodule AssertCallVerification do
+        def function() do
+          self()
+        end
+      end,
+      defmodule AssertCallVerification do
+        def function() do
+          &self/0
+        end
+      end
+    ]
+  end
+end

--- a/test/elixir_analyzer/test_suite/rpn_calculator_inspection_test.exs
+++ b/test/elixir_analyzer/test_suite/rpn_calculator_inspection_test.exs
@@ -18,6 +18,42 @@ defmodule ElixirAnalyzer.ExerciseTest.RpnCalculatorInspectionTest do
         end
 
         # More functions...
+      end,
+      defmodule RPNCalculatorInspection do
+        def start_reliability_check(calculator, input) do
+          pid = Kernel.spawn_link(fn -> calculator.(input) end)
+          %{pid: pid, input: input}
+        end
+
+        def await_reliability_check_result(%{pid: pid, input: input}, results) do
+          receive do
+            {:EXIT, ^pid, :normal} -> results |> Map.put(input, :ok)
+            {:EXIT, ^pid, _error} -> results |> Map.put(input, :error)
+          after
+            100 -> results |> Map.put(input, :timeout)
+          end
+        end
+
+        def reliability_check(calculator, inputs) do
+          {_trap_exit, init_trap_exit} = Process.info(self(), :trap_exit)
+          Process.flag(:trap_exit, true)
+
+          results =
+            inputs
+            |> Enum.map(fn input -> start_reliability_check(calculator, input) end)
+            |> Enum.map(fn check -> await_reliability_check_result(check, %{}) end)
+            |> Enum.flat_map(fn result -> result end)
+            |> Enum.into(%{})
+
+          Process.flag(:trap_exit, init_trap_exit)
+          results
+        end
+
+        def correctness_check(calculator, inputs) do
+          inputs
+          |> Enum.map(fn input -> Task.async(fn -> calculator.(input) end) end)
+          |> Enum.map(fn task -> Task.await(task, 100) end)
+        end
       end
     ]
   end

--- a/test/support/analyzer_verification/assert_call/kernel_functions.ex
+++ b/test/support/analyzer_verification/assert_call/kernel_functions.ex
@@ -1,6 +1,6 @@
 defmodule ElixirAnalyzer.Support.AnalyzerVerification.AssertCall.Kernel do
   @moduledoc """
-  This is an exercise analyzer extension module to test the assert_call and assert_no_call 
+  This is an exercise analyzer extension module to test the assert_call and assert_no_call
   macros specifically for finding Kernel functions
   """
 

--- a/test/support/analyzer_verification/assert_call/kernel_functions.ex
+++ b/test/support/analyzer_verification/assert_call/kernel_functions.ex
@@ -1,0 +1,32 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.AssertCall.Kernel do
+  @moduledoc """
+  This is an exercise analyzer extension module to test the assert_call and assert_no_call 
+  macros specifically for finding Kernel functions
+  """
+
+  use ElixirAnalyzer.ExerciseTest
+
+  assert_call "finds call to Kernel.dbg/0 with explicit module" do
+    type :informative
+    called_fn module: Kernel, name: :dbg
+    comment "didn't find a call to Kernel.dbg/0"
+  end
+
+  assert_call "finds call to Kernel.dbg/0 without module" do
+    type :informative
+    called_fn name: :dbg
+    comment "didn't find a call to dbg/0"
+  end
+
+  assert_call "finds call to Kernel.self/0 with explicit module" do
+    type :informative
+    called_fn module: Kernel, name: :self
+    comment "didn't find a call to Kernel.self/0"
+  end
+
+  assert_call "finds call to Kernel.self/0 without module" do
+    type :informative
+    called_fn name: :self
+    comment "didn't find a call to self/0"
+  end
+end


### PR DESCRIPTION
Fixes #343 