### PR TITLE
Be consistent when invoking bash in scripts

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
This aligns with the other scripts which are already invoking bash with `/usr/bin/env bash`.