### PR TITLE
Allow ::8 or ::size(8) in file-sniffer pattern matching

### DIFF
--- a/lib/elixir_analyzer/test_suite/file_sniffer.ex
+++ b/lib/elixir_analyzer/test_suite/file_sniffer.ex
@@ -18,6 +18,22 @@ defmodule ElixirAnalyzer.TestSuite.FileSniffer do
     form do
       <<0x42, 0x4D>>
     end
+
+    form do
+      <<0x42::8, 0x4D::8, _ignore>>
+    end
+
+    form do
+      <<0x42::8, 0x4D::8>>
+    end
+
+    form do
+      <<0x42::size(8), 0x4D::size(8), _ignore>>
+    end
+
+    form do
+      <<0x42::size(8), 0x4D::size(8)>>
+    end
   end
 
   feature "use pattern matching for png" do
@@ -31,6 +47,24 @@ defmodule ElixirAnalyzer.TestSuite.FileSniffer do
 
     form do
       <<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A>>
+    end
+
+    form do
+      <<0x89::8, 0x50::8, 0x4E::8, 0x47::8, 0x0D::8, 0x0A::8, 0x1A::8, 0x0A::8, _ignore>>
+    end
+
+    form do
+      <<0x89::8, 0x50::8, 0x4E::8, 0x47::8, 0x0D::8, 0x0A::8, 0x1A::8, 0x0A::8>>
+    end
+
+    form do
+      <<0x89::size(8), 0x50::size(8), 0x4E::size(8), 0x47::size(8), 0x0D::size(8), 0x0A::size(8),
+        0x1A::size(8), 0x0A::size(8), _ignore>>
+    end
+
+    form do
+      <<0x89::size(8), 0x50::size(8), 0x4E::size(8), 0x47::size(8), 0x0D::size(8), 0x0A::size(8),
+        0x1A::size(8), 0x0A::size(8)>>
     end
   end
 
@@ -46,6 +80,22 @@ defmodule ElixirAnalyzer.TestSuite.FileSniffer do
     form do
       <<0xFF, 0xD8, 0xFF>>
     end
+
+    form do
+      <<0xFF::8, 0xD8::8, 0xFF::8, _ignore>>
+    end
+
+    form do
+      <<0xFF::8, 0xD8::8, 0xFF::8>>
+    end
+
+    form do
+      <<0xFF::size(8), 0xD8::size(8), 0xFF::size(8), _ignore>>
+    end
+
+    form do
+      <<0xFF::size(8), 0xD8::size(8), 0xFF::size(8)>>
+    end
   end
 
   feature "use pattern matching for gif" do
@@ -60,6 +110,22 @@ defmodule ElixirAnalyzer.TestSuite.FileSniffer do
     form do
       <<0x47, 0x49, 0x46>>
     end
+
+    form do
+      <<0x47::8, 0x49::8, 0x46::8, _ignore>>
+    end
+
+    form do
+      <<0x47::8, 0x49::8, 0x46::8>>
+    end
+
+    form do
+      <<0x47::size(8), 0x49::size(8), 0x46::size(8), _ignore>>
+    end
+
+    form do
+      <<0x47::size(8), 0x49::size(8), 0x46::size(8)>>
+    end
   end
 
   feature "use pattern matching for exe" do
@@ -73,6 +139,22 @@ defmodule ElixirAnalyzer.TestSuite.FileSniffer do
 
     form do
       <<0x7F, 0x45, 0x4C, 0x46>>
+    end
+
+    form do
+      <<0x7F::8, 0x45::8, 0x4C::8, 0x46::8, _ignore>>
+    end
+
+    form do
+      <<0x7F::8, 0x45::8, 0x4C::8, 0x46::8>>
+    end
+
+    form do
+      <<0x7F::size(8), 0x45::size(8), 0x4C::size(8), 0x46::size(8), _ignore>>
+    end
+
+    form do
+      <<0x7F::size(8), 0x45::size(8), 0x4C::size(8), 0x46::size(8)>>
     end
   end
 end

--- a/test/elixir_analyzer/test_suite/file_sniffer_test.exs
+++ b/test/elixir_analyzer/test_suite/file_sniffer_test.exs
@@ -106,6 +106,47 @@ defmodule ElixirAnalyzer.ExerciseTest.FileSnifferTest do
             <<0x47, 0x49, 0x46, _::binary>> -> "image/gif"
           end
         end
+      end,
+      defmodule FileSniffer do
+        def type_from_binary(<<head::binary-size(8), _::binary>>) do
+          case head do
+            <<0x7F::8, 0x45::8, 0x4C::8, 0x46::8, _::binary>> ->
+              "application/octet-stream"
+
+            <<0x42::8, 0x4D::8, _::binary>> ->
+              "image/bmp"
+
+            <<0x89::8, 0x50::8, 0x4E::8, 0x47::8, 0x0D::8, 0x0A::8, 0x1A::8, 0x0A::8>> ->
+              "image/png"
+
+            <<0xFF::8, 0xD8::8, 0xFF::8, _::binary>> ->
+              "image/jpg"
+
+            <<0x47::8, 0x49::8, 0x46::8, _::binary>> ->
+              "image/gif"
+          end
+        end
+      end,
+      defmodule FileSniffer do
+        def type_from_binary(<<head::binary-size(8), _::binary>>) do
+          case head do
+            <<0x7F::size(8), 0x45::size(8), 0x4C::size(8), 0x46::size(8), _::binary>> ->
+              "application/octet-stream"
+
+            <<0x42::size(8), 0x4D::size(8), _::binary>> ->
+              "image/bmp"
+
+            <<0x89::size(8), 0x50::size(8), 0x4E::size(8), 0x47::size(8), 0x0D::size(8),
+              0x0A::size(8), 0x1A::size(8), 0x0A::size(8)>> ->
+              "image/png"
+
+            <<0xFF::size(8), 0xD8::size(8), 0xFF::size(8), _::binary>> ->
+              "image/jpg"
+
+            <<0x47::size(8), 0x49::size(8), 0x46::size(8), _::binary>> ->
+              "image/gif"
+          end
+        end
       end
     ]
   end


### PR DESCRIPTION
Resolves https://github.com/exercism/elixir-analyzer/issues/353

This is very not-dry 😬 is it good enough or should I look into doing more meta programming with `check_source`?

Also, I am not entirely sure if no size, `8`, and `size(8)` are the only three valid options. That's the only ones I could think of, but maybe there's more?