### PR TITLE
Handle def+rescue in assert_call

### DIFF
--- a/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
+++ b/lib/elixir_analyzer/exercise_test/assert_call/compiler.ex
@@ -268,7 +268,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
   @doc """
   node is a function definition
   """
-  def function_def?({def_type, _, [_, [do: _]]}) when def_type in ~w[def defp]a do
+  def function_def?({def_type, _, [_, [{:do, _} | _]]}) when def_type in ~w[def defp]a do
     true
   end
 
@@ -277,11 +277,11 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.Compiler do
   @doc """
   get the name of a function from a function definition node
   """
-  def extract_function_name({def_type, _, [{:when, _, [{name, _, _} | _]}, [do: _]]})
+  def extract_function_name({def_type, _, [{:when, _, [{name, _, _} | _]}, [{:do, _} | _]]})
       when is_atom(name) and def_type in ~w[def defp]a,
       do: name
 
-  def extract_function_name({def_type, _, [{name, _, _}, [do: _]]})
+  def extract_function_name({def_type, _, [{name, _, _}, [{:do, _} | _]]})
       when is_atom(name) and def_type in ~w[def defp]a,
       do: name
 

--- a/test/elixir_analyzer/exercise_test/assert_call/indirect_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call/indirect_call_test.exs
@@ -66,6 +66,30 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCall.IndirectCallTest do
           final_function(:math.pi())
         end
       end,
+      # via two helpers with unnecessary but harmless rescue blocks
+      defmodule AssertCallVerification do
+        def main_function() do
+          helper("")
+          |> do_something()
+        rescue
+          _ -> :oops
+        end
+
+        def helper(path) do
+          helper_2(path)
+        rescue
+          _ -> :oops
+        end
+
+        defp helper_2(path) do
+          Elixir.Mix.Utils.read_path(path)
+
+          :math.pi()
+          |> final_function
+        rescue
+          _ -> :oops
+        end
+      end,
       # via two helpers unnecessarily referencing the module in local calls
       defmodule AssertCallVerification do
         def main_function() do

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -39,6 +39,27 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
         defp private_helper do
           :privately_helped
         end
+      end,
+      # function definitions with unnecessary but harmless rescue blocks
+      defmodule AssertCallVerification do
+        def function() do
+          x = List.first([1, 2, 3])
+          result = helper()
+          IO.puts(result)
+
+          private_helper() |> IO.puts()
+        rescue
+          ArgumentError -> :oops
+          _ -> :what
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
       end
     ]
   end

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -64,6 +64,34 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
     ]
   end
 
+  test_exercise_analysis "finds calls even if they're in rescue blocks",
+    comments: [] do
+    [
+      # def + rescue and try + rescue
+      defmodule AssertCallVerification do
+        def function() do
+          try do
+            x = List.first([1, 2, 3])
+          rescue
+            result = helper()
+            IO.puts(result)
+          end
+        rescue
+          ArgumentError -> :oops
+          _ -> private_helper() |> IO.puts()
+        end
+
+        def helper do
+          :helped
+        end
+
+        defp private_helper do
+          :privately_helped
+        end
+      end
+    ]
+  end
+
   test_exercise_analysis "missing local call from anywhere in solution",
     comments: [
       "didn't find a local call to helper/0",

--- a/test/elixir_analyzer/test_suite/high_score_test.exs
+++ b/test/elixir_analyzer/test_suite/high_score_test.exs
@@ -60,6 +60,41 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
         def get_players(scores) do
           Map.keys(scores)
         end
+      end,
+      defmodule HighScore do
+        @initial_score 0
+
+        def new(), do: %{}
+
+        def add_player(scores, name, score \\ @initial_score) do
+          Map.put(scores, name, score)
+        rescue
+          _ -> "this is completely unnecessary"
+        end
+
+        def remove_player(scores, name) do
+          Map.delete(scores, name)
+        rescue
+          _ -> "this is completely unnecessary"
+        end
+
+        def reset_score(scores, name) do
+          scores |> remove_player(name) |> add_player(name)
+        rescue
+          _ -> "this is completely unnecessary"
+        end
+
+        def update_score(scores, name, score) do
+          Map.update(scores, name, score, &(&1 + score))
+        rescue
+          _ -> "this is completely unnecessary"
+        end
+
+        def get_players(scores) do
+          Map.keys(scores)
+        rescue
+          _ -> "this is completely unnecessary"
+        end
       end
     ]
   end

--- a/test/elixir_analyzer/test_suite/high_score_test.exs
+++ b/test/elixir_analyzer/test_suite/high_score_test.exs
@@ -68,8 +68,6 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
 
         def add_player(scores, name, score \\ @initial_score) do
           Map.put(scores, name, score)
-        rescue
-          _ -> "this is completely unnecessary"
         end
 
         def remove_player(scores, name) do


### PR DESCRIPTION
This PR partially deals with https://github.com/exercism/elixir-analyzer/issues/350 by handling `def` and `defp` with `rescue` blocks in `assert_call`.

It doesn't deal with the fact that we used `form do def foo()...` in many places and those won't work with `def+rescue`. However, I don't think we should change that.

Instead, I think we should add a common check to all learning exercises that don't require any rescuing that warns students that using raising and rescuing errors for flow control is an antipattern and might result in other analyzer feedback being invalid.