### PR TITLE
Add common check for not using `rescue`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -99,6 +99,9 @@ config :elixir_analyzer,
     "rpg-character-sheet" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.RpgCharacterSheet
     },
+    "rpn-calculator" => %{
+      analyzer_module: ElixirAnalyzer.TestSuite.RpnCalculator
+    },
     "rpn-calculator-inspection" => %{
       analyzer_module: ElixirAnalyzer.TestSuite.RpnCalculatorInspection
     },

--- a/lib/elixir_analyzer/constants.ex
+++ b/lib/elixir_analyzer/constants.ex
@@ -42,6 +42,7 @@ defmodule ElixirAnalyzer.Constants do
     solution_unless_with_else: "elixir.solution.unless_with_else",
     solution_use_function_capture: "elixir.solution.use_function_capture",
     solution_deprecated_random_module: "elixir.solution.deprecated_random_module",
+    solution_no_rescue: "elixir.solution.no_rescue",
 
     # Concept exercises
 

--- a/lib/elixir_analyzer/exercise_test/common_checks.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks.ex
@@ -30,6 +30,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks do
       use ElixirAnalyzer.ExerciseTest.CommonChecks.UncommonErrors
       use ElixirAnalyzer.ExerciseTest.CommonChecks.UnlessWithElse
       use ElixirAnalyzer.ExerciseTest.CommonChecks.DeprecatedRandomModule
+      use ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescue
     end
   end
 

--- a/lib/elixir_analyzer/exercise_test/common_checks/no_rescue.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/no_rescue.ex
@@ -1,0 +1,65 @@
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescue do
+  @moduledoc """
+  This is an exercise analyzer extension module used for common tests looking for the usage of `rescue`
+  """
+
+  alias ElixirAnalyzer.Constants
+
+  defmacro __using__(_opts) do
+    quote do
+      feature Constants.solution_no_rescue() do
+        type :essential
+        comment Constants.solution_no_rescue()
+        find :none
+
+        form do
+          def _ignore do
+            _ignore
+          rescue
+            _ignore
+          end
+        end
+
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          end
+        end
+
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          else
+            _ignore
+          end
+        end
+
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          after
+            _ignore
+          end
+        end
+
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          else
+            _ignore
+          after
+            _ignore
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/elixir_analyzer/exercise_test/common_checks/no_rescue.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/no_rescue.ex
@@ -12,6 +12,61 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescue do
         comment Constants.solution_no_rescue()
         find :none
 
+        # try ------------------------------------------------------------------------
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          end
+        end
+
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          else
+            _ignore
+          end
+        end
+
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          after
+            _ignore
+          end
+        end
+
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          else
+            _ignore
+          after
+            _ignore
+          end
+        end
+
+        form do
+          try do
+            _ignore
+          rescue
+            _ignore
+          after
+            _ignore
+          else
+            _ignore
+          end
+        end
+
+        # def ------------------------------------------------------------------------
+
         form do
           def _ignore do
             _ignore
@@ -21,15 +76,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescue do
         end
 
         form do
-          try do
-            _ignore
-          rescue
-            _ignore
-          end
-        end
-
-        form do
-          try do
+          def _ignore do
             _ignore
           rescue
             _ignore
@@ -39,7 +86,7 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescue do
         end
 
         form do
-          try do
+          def _ignore do
             _ignore
           rescue
             _ignore
@@ -49,13 +96,79 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescue do
         end
 
         form do
-          try do
+          def _ignore do
             _ignore
           rescue
             _ignore
           else
             _ignore
           after
+            _ignore
+          end
+        end
+
+        form do
+          def _ignore do
+            _ignore
+          rescue
+            _ignore
+          after
+            _ignore
+          else
+            _ignore
+          end
+        end
+
+        # defp -----------------------------------------------------------------------
+
+        form do
+          defp _ignore do
+            _ignore
+          rescue
+            _ignore
+          end
+        end
+
+        form do
+          defp _ignore do
+            _ignore
+          rescue
+            _ignore
+          else
+            _ignore
+          end
+        end
+
+        form do
+          defp _ignore do
+            _ignore
+          rescue
+            _ignore
+          after
+            _ignore
+          end
+        end
+
+        form do
+          defp _ignore do
+            _ignore
+          rescue
+            _ignore
+          else
+            _ignore
+          after
+            _ignore
+          end
+        end
+
+        form do
+          defp _ignore do
+            _ignore
+          rescue
+            _ignore
+          after
+            _ignore
+          else
             _ignore
           end
         end

--- a/lib/elixir_analyzer/exercise_test/common_checks/no_rescue.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/no_rescue.ex
@@ -1,178 +1,33 @@
-# credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
-
 defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescue do
   @moduledoc """
   This is an exercise analyzer extension module used for common tests looking for the usage of `rescue`
   """
 
   alias ElixirAnalyzer.Constants
+  alias ElixirAnalyzer.Source
 
   defmacro __using__(_opts) do
     quote do
-      feature Constants.solution_no_rescue() do
+      check_source Constants.solution_no_rescue() do
         type :essential
         comment Constants.solution_no_rescue()
-        find :none
 
-        # try ------------------------------------------------------------------------
-        form do
-          try do
-            _ignore
-          rescue
-            _ignore
-          end
-        end
+        check(%Source{code_ast: code_ast}) do
+          {_, found} =
+            Macro.prewalk(code_ast, false, fn node, found ->
+              case node do
+                {def_op, _, [_function, [{:do, _} | rest]]} when def_op in [:def, :defp] ->
+                  {node, found or List.keymember?(rest, :rescue, 0)}
 
-        form do
-          try do
-            _ignore
-          rescue
-            _ignore
-          else
-            _ignore
-          end
-        end
+                {:try, _, [[{:do, _} | rest]]} ->
+                  {node, found or List.keymember?(rest, :rescue, 0)}
 
-        form do
-          try do
-            _ignore
-          rescue
-            _ignore
-          after
-            _ignore
-          end
-        end
+                _ ->
+                  {node, found}
+              end
+            end)
 
-        form do
-          try do
-            _ignore
-          rescue
-            _ignore
-          else
-            _ignore
-          after
-            _ignore
-          end
-        end
-
-        form do
-          try do
-            _ignore
-          rescue
-            _ignore
-          after
-            _ignore
-          else
-            _ignore
-          end
-        end
-
-        # def ------------------------------------------------------------------------
-
-        form do
-          def _ignore do
-            _ignore
-          rescue
-            _ignore
-          end
-        end
-
-        form do
-          def _ignore do
-            _ignore
-          rescue
-            _ignore
-          else
-            _ignore
-          end
-        end
-
-        form do
-          def _ignore do
-            _ignore
-          rescue
-            _ignore
-          after
-            _ignore
-          end
-        end
-
-        form do
-          def _ignore do
-            _ignore
-          rescue
-            _ignore
-          else
-            _ignore
-          after
-            _ignore
-          end
-        end
-
-        form do
-          def _ignore do
-            _ignore
-          rescue
-            _ignore
-          after
-            _ignore
-          else
-            _ignore
-          end
-        end
-
-        # defp -----------------------------------------------------------------------
-
-        form do
-          defp _ignore do
-            _ignore
-          rescue
-            _ignore
-          end
-        end
-
-        form do
-          defp _ignore do
-            _ignore
-          rescue
-            _ignore
-          else
-            _ignore
-          end
-        end
-
-        form do
-          defp _ignore do
-            _ignore
-          rescue
-            _ignore
-          after
-            _ignore
-          end
-        end
-
-        form do
-          defp _ignore do
-            _ignore
-          rescue
-            _ignore
-          else
-            _ignore
-          after
-            _ignore
-          end
-        end
-
-        form do
-          defp _ignore do
-            _ignore
-          rescue
-            _ignore
-          after
-            _ignore
-          else
-            _ignore
-          end
+          not found
         end
       end
     end

--- a/lib/elixir_analyzer/exercise_test/common_checks/no_rescue.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/no_rescue.ex
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Refactor.LongQuoteBlocks
+
 defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescue do
   @moduledoc """
   This is an exercise analyzer extension module used for common tests looking for the usage of `rescue`

--- a/lib/elixir_analyzer/test_suite/rpn_calculator.ex
+++ b/lib/elixir_analyzer/test_suite/rpn_calculator.ex
@@ -1,0 +1,8 @@
+defmodule ElixirAnalyzer.TestSuite.RpnCalculator do
+  @moduledoc """
+  This is an exercise analyzer extension module for the concept exercise rpn-calculator
+  """
+
+  alias ElixirAnalyzer.Constants
+  use ElixirAnalyzer.ExerciseTest, suppress_tests: [Constants.solution_no_rescue()]
+end

--- a/lib/elixir_analyzer/test_suite/rpn_calculator_output.ex
+++ b/lib/elixir_analyzer/test_suite/rpn_calculator_output.ex
@@ -3,8 +3,8 @@ defmodule ElixirAnalyzer.TestSuite.RpnCalculatorOutput do
   This is an exercise analyzer extension module for the concept exercise rpn-calculator-output
   """
 
-  use ElixirAnalyzer.ExerciseTest
   alias ElixirAnalyzer.Constants
+  use ElixirAnalyzer.ExerciseTest, suppress_tests: [Constants.solution_no_rescue()]
 
   feature "uses all of try-rescue-else-after" do
     type :essential

--- a/test/elixir_analyzer/exercise_test/assert_call_test.exs
+++ b/test/elixir_analyzer/exercise_test/assert_call_test.exs
@@ -39,8 +39,13 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
         defp private_helper do
           :privately_helped
         end
-      end,
-      # function definitions with unnecessary but harmless rescue blocks
+      end
+    ]
+  end
+
+  test_exercise_analysis "perfect solution with unnecessary but harmless rescue blocks",
+    comments: [ElixirAnalyzer.Constants.solution_no_rescue()] do
+    [
       defmodule AssertCallVerification do
         def function() do
           x = List.first([1, 2, 3])
@@ -65,7 +70,7 @@ defmodule ElixirAnalyzer.ExerciseTest.AssertCallTest do
   end
 
   test_exercise_analysis "finds calls even if they're in rescue blocks",
-    comments: [] do
+    comments: [ElixirAnalyzer.Constants.solution_no_rescue()] do
     [
       # def + rescue and try + rescue
       defmodule AssertCallVerification do

--- a/test/elixir_analyzer/exercise_test/common_checks/no_rescue_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/no_rescue_test.exs
@@ -1,3 +1,5 @@
+# credo:disable-for-this-file Credo.Check.Warning.IoInspect
+
 defmodule ElixirAnalyzer.Support.AnalyzerVerification.NoRescue do
   use ElixirAnalyzer.ExerciseTest
 end

--- a/test/elixir_analyzer/exercise_test/common_checks/no_rescue_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/no_rescue_test.exs
@@ -1,0 +1,331 @@
+defmodule ElixirAnalyzer.Support.AnalyzerVerification.NoRescue do
+  use ElixirAnalyzer.ExerciseTest
+end
+
+defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescueTest do
+  use ElixirAnalyzer.ExerciseTestCase,
+    exercise_test_module: ElixirAnalyzer.Support.AnalyzerVerification.NoRescue
+
+  alias ElixirAnalyzer.Constants
+
+  test_exercise_analysis "Solutions without rescue",
+    comments: [] do
+    [
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          result = Date.new(1999, month, 1)
+
+          case result do
+            {:ok, date} -> date
+            {:error, _error} -> nil
+          end
+        end
+      end
+    ]
+  end
+
+  test_exercise_analysis "Solutions with rescuing",
+    comments_include: [Constants.solution_no_rescue()] do
+    [
+      # try/rescue
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            Date.new!(1999, month, 1)
+          rescue
+            _ ->
+              nil
+          end
+        end
+      end,
+      # try/rescue multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            IO.inspect(month)
+            Date.new!(1999, month, 1)
+          rescue
+            error ->
+              IO.inspect(error)
+              nil
+          end
+        end
+      end,
+      # try/rescue multi clause
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            IO.inspect(month)
+            Date.new!(1999, month, 1)
+          rescue
+            error in [RuntimeError] ->
+              IO.inspect(error)
+              nil
+
+            error in [ArgumentError] ->
+              IO.inspect(error)
+              nil
+          end
+        end
+      end,
+      # try/rescue/else multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            IO.inspect(month)
+            Date.new!(1999, month, 1)
+          rescue
+            error ->
+              IO.inspect(error)
+              nil
+          else
+            the_value ->
+              IO.inspect("my code is so bad, what am I doing with my life?")
+              the_value
+          end
+        end
+      end,
+      # try/rescue/after multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            IO.inspect(month)
+            Date.new!(1999, month, 1)
+          rescue
+            error ->
+              IO.inspect(error)
+              nil
+          after
+            IO.inspect("stop")
+            IO.inspect("please")
+          end
+        end
+      end,
+      # try/rescue/else/after multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            IO.inspect(month)
+            Date.new!(1999, month, 1)
+          rescue
+            error ->
+              IO.inspect(error)
+              nil
+          else
+            the_value ->
+              IO.inspect("my code is so bad, what am I doing with my life?")
+              the_value
+          after
+            IO.inspect("stop")
+            IO.inspect("please")
+          end
+        end
+      end,
+      # try/rescue/after/else multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            IO.inspect(month)
+            Date.new!(1999, month, 1)
+          rescue
+            error ->
+              IO.inspect(error)
+              nil
+          after
+            IO.inspect("stop")
+            IO.inspect("please")
+          else
+            the_value ->
+              IO.inspect("my code is so bad, what am I doing with my life?")
+              the_value
+          end
+        end
+      end,
+      # try/rescue/after/else multi clause else multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            IO.inspect(month)
+            Date.new!(1999, month, 1)
+          rescue
+            error ->
+              IO.inspect(error)
+              nil
+          after
+            IO.inspect("stop")
+            IO.inspect("please")
+          else
+            :foo ->
+              :bar
+
+            the_value ->
+              IO.inspect("my code is so bad, what am I doing with my life?")
+              the_value
+          end
+        end
+      end,
+      # def/rescue
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          Date.new!(1999, month, 1)
+        rescue
+          _ ->
+            nil
+        end
+      end,
+      # def/rescue multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error ->
+            IO.inspect(error)
+            nil
+        end
+      end,
+      # def/rescue/else multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error in [ArgumentError] ->
+            IO.inspect(error)
+            nil
+        else
+          the_value ->
+            IO.inspect("my code is so bad, what am I doing with my life?")
+            the_value
+        end
+      end,
+      # def/rescue/after multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error in [ArgumentError] ->
+            IO.inspect(error)
+            nil
+        after
+          IO.inspect("stop")
+          IO.inspect("please")
+        end
+      end,
+      # def/rescue/else/after multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error in [ArgumentError] ->
+            IO.inspect(error)
+            nil
+        else
+          the_value ->
+            IO.inspect("my code is so bad, what am I doing with my life?")
+            the_value
+        after
+          IO.inspect("stop")
+          IO.inspect("please")
+        end
+      end,
+      # def/rescue/after/else multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error in [ArgumentError] ->
+            IO.inspect(error)
+            nil
+        after
+          IO.inspect("stop")
+          IO.inspect("please")
+        else
+          the_value ->
+            IO.inspect("my code is so bad, what am I doing with my life?")
+            the_value
+        end
+      end,
+
+      # defp/rescue multiline blocks
+      defmodule MyModule do
+        defp get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error ->
+            IO.inspect(error)
+            nil
+        end
+      end,
+      # defp/rescue/else multiline blocks
+      defmodule MyModule do
+        defp get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error in [ArgumentError] ->
+            IO.inspect(error)
+            nil
+        else
+          the_value ->
+            IO.inspect("my code is so bad, what am I doing with my life?")
+            the_value
+        end
+      end,
+      # defp/rescue/after multiline blocks
+      defmodule MyModule do
+        defp get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error in [ArgumentError] ->
+            IO.inspect(error)
+            nil
+        after
+          IO.inspect("stop")
+          IO.inspect("please")
+        end
+      end,
+      # defp/rescue/else/after multiline blocks
+      defmodule MyModule do
+        defp get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error in [ArgumentError] ->
+            IO.inspect(error)
+            nil
+        else
+          the_value ->
+            IO.inspect("my code is so bad, what am I doing with my life?")
+            the_value
+        after
+          IO.inspect("stop")
+          IO.inspect("please")
+        end
+      end,
+      # defp/rescue/after/else multiline blocks
+      defmodule MyModule do
+        defp get_first_day_of_month_in_99(month) do
+          IO.inspect(month)
+          Date.new!(1999, month, 1)
+        rescue
+          error in [ArgumentError] ->
+            IO.inspect(error)
+            nil
+        after
+          IO.inspect("stop")
+          IO.inspect("please")
+        else
+          the_value ->
+            IO.inspect("my code is so bad, what am I doing with my life?")
+            the_value
+        end
+      end
+    ]
+  end
+end

--- a/test/elixir_analyzer/exercise_test/common_checks/no_rescue_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks/no_rescue_test.exs
@@ -143,6 +143,29 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.NoRescueTest do
           end
         end
       end,
+      # try/rescue/catch/after/else multiline blocks
+      defmodule MyModule do
+        def get_first_day_of_month_in_99(month) do
+          try do
+            IO.inspect(month)
+            Date.new!(1999, month, 1)
+          rescue
+            error ->
+              IO.inspect(error)
+              nil
+          catch
+            value ->
+              IO.puts("Caught #{inspect(value)}")
+          after
+            IO.inspect("stop")
+            IO.inspect("please")
+          else
+            the_value ->
+              IO.inspect("my code is so bad, what am I doing with my life?")
+              the_value
+          end
+        end
+      end,
       # try/rescue/after/else multi clause else multiline blocks
       defmodule MyModule do
         def get_first_day_of_month_in_99(month) do

--- a/test/elixir_analyzer/test_suite/high_score_test.exs
+++ b/test/elixir_analyzer/test_suite/high_score_test.exs
@@ -60,7 +60,13 @@ defmodule ElixirAnalyzer.ExerciseTest.HighScoreTest do
         def get_players(scores) do
           Map.keys(scores)
         end
-      end,
+      end
+    ]
+  end
+
+  test_exercise_analysis "other solutions with rescue",
+    comments: [ElixirAnalyzer.Constants.solution_no_rescue()] do
+    [
       defmodule HighScore do
         @initial_score 0
 

--- a/test/elixir_analyzer/test_suite/list_ops_test.exs
+++ b/test/elixir_analyzer/test_suite/list_ops_test.exs
@@ -57,7 +57,7 @@ defmodule ElixirAnalyzer.ExerciseTest.ListOpsTest do
   end
 
   test_exercise_analysis "illegal implementations",
-    comments: [Constants.list_ops_do_not_use_list_functions()] do
+    comments_include: [Constants.list_ops_do_not_use_list_functions()] do
     [
       defmodule ListOps do
         def filter(p, l), do: Enum.filter(p, l)


### PR DESCRIPTION
Comment PR: https://github.com/exercism/website-copy/pull/2250

This PR treats all usages of `rescue` as bad, except for the two concept exercises that teach how to use `rescue.`.