### PR TITLE
Relax german-sysadmin integer literal check

### DIFF
--- a/lib/elixir_analyzer/test_suite/german_sysadmin.ex
+++ b/lib/elixir_analyzer/test_suite/german_sysadmin.ex
@@ -36,11 +36,28 @@ defmodule ElixirAnalyzer.TestSuite.GermanSysadmin do
     comment Constants.solution_no_integer_literal()
 
     check(%Source{code_string: code_string}) do
-      question_mark_code_points = ["?ß", "?ä", "?ö", "?ü", "?_", "?a", "?z"]
-      integer_literal_code_points = ["223", "228", "246", "252", "95", "97", "122"]
+      question_mark_and_integer_literal_pairs = [
+        {"?ß", "223"},
+        {"?ä", "228"},
+        {"?ö", "246"},
+        {"?ü", "252"},
+        {"?_", "95"},
+        {"?a", "97"},
+        {"?z", "122"}
+      ]
 
+      question_mark_code_points = Enum.map(question_mark_and_integer_literal_pairs, &elem(&1, 0))
+
+      # require at least one question mark code point and
+      # allow integer literal code points if their equivalent question mark code point was also used
       Enum.any?(question_mark_code_points, &String.contains?(code_string, &1)) &&
-        not Enum.any?(integer_literal_code_points, &String.contains?(code_string, &1))
+        not Enum.any?(
+          question_mark_and_integer_literal_pairs,
+          fn {question_mark_code_point, integer_literal_code_point} ->
+            not String.contains?(code_string, question_mark_code_point) &&
+              String.contains?(code_string, integer_literal_code_point)
+          end
+        )
     end
   end
 

--- a/lib/elixir_analyzer/test_suite/german_sysadmin.ex
+++ b/lib/elixir_analyzer/test_suite/german_sysadmin.ex
@@ -36,8 +36,11 @@ defmodule ElixirAnalyzer.TestSuite.GermanSysadmin do
     comment Constants.solution_no_integer_literal()
 
     check(%Source{code_string: code_string}) do
-      integers = ["?ß", "?ä", "?ö", "?ü", "?_", "?a", "?z"]
-      Enum.all?(integers, &String.contains?(code_string, &1))
+      question_mark_code_points = ["?ß", "?ä", "?ö", "?ü", "?_", "?a", "?z"]
+      integer_literal_code_points = ["223", "228", "246", "252", "95", "97", "122"]
+
+      Enum.any?(question_mark_code_points, &String.contains?(code_string, &1)) &&
+        not Enum.any?(integer_literal_code_points, &String.contains?(code_string, &1))
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,6 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/elixir_analyzer/test_suite/german_sysadmin_test.exs
+++ b/test/elixir_analyzer/test_suite/german_sysadmin_test.exs
@@ -30,26 +30,47 @@ defmodule ElixirAnalyzer.ExerciseTest.GermanSysadminTest do
 
   test_exercise_analysis "other valid solutions",
     comments: [] do
-    ~S"""
-    defmodule Username do
-      def sanitize(list) do
-        List.foldr(list, [], fn code, acc ->
-          sanitized =
-            case code do
-              ?ß -> ~c"ss"
-              ?ä -> ~c"ae"
-              ?ö -> ~c"oe"
-              ?ü -> ~c"ue"
-              x when x >= ?a and x <= ?z -> [x]
-              ?_ -> ~c"_"
-              _ -> ~c""
-            end
+    [
+      ~S"""
+      defmodule Username do
+        def sanitize(list) do
+          List.foldr(list, [], fn code, acc ->
+            sanitized =
+              case code do
+                ?ß -> ~c"ss"
+                ?ä -> ~c"ae"
+                ?ö -> ~c"oe"
+                ?ü -> ~c"ue"
+                x when x >= ?a and x <= ?z -> [x]
+                ?_ -> ~c"_"
+                _ -> ~c""
+              end
 
-          sanitized ++ acc
-        end)
+            sanitized ++ acc
+          end)
+        end
       end
-    end
-    """
+      """,
+      """
+      defmodule Username do
+      @spec sanitize(charlist) :: charlist
+      def sanitize(username) do
+        username
+        |> Enum.filter(&(&1 in ~c"äöüßabcdefghijklmnopqrstuvwxyz_"))
+        |> Enum.reduce([], fn char, list ->
+          case char do
+            ?ä -> [?e, ?a | list]
+            ?ö -> [?e, ?o | list]
+            ?ü -> [?e, ?u | list]
+            ?ß -> [?s, ?s | list]
+            c -> [c | list]
+          end
+        end)
+        |> Enum.reverse()
+      end
+      end
+      """
+    ]
   end
 
   test_exercise_analysis "detects cheating with strings",

--- a/test/elixir_analyzer/test_suite/german_sysadmin_test.exs
+++ b/test/elixir_analyzer/test_suite/german_sysadmin_test.exs
@@ -37,6 +37,7 @@ defmodule ElixirAnalyzer.ExerciseTest.GermanSysadminTest do
           List.foldr(list, [], fn code, acc ->
             sanitized =
               case code do
+                # 223
                 ?ß -> ~c"ss"
                 ?ä -> ~c"ae"
                 ?ö -> ~c"oe"

--- a/test/elixir_analyzer/test_suite/pacman_rules_test.exs
+++ b/test/elixir_analyzer/test_suite/pacman_rules_test.exs
@@ -5,20 +5,20 @@ defmodule ElixirAnalyzer.ExerciseTest.PacmanRulesTest do
   test_exercise_analysis "example solution",
     comments: [ElixirAnalyzer.Constants.solution_same_as_exemplar()] do
     defmodule Rules do
-      def eat_ghost?(power_pellet_active, touching_ghost) do
-        power_pellet_active and touching_ghost
+      def eat_ghost?(power_pellet_active?, touching_ghost?) do
+        power_pellet_active? and touching_ghost?
       end
 
-      def score?(touching_power_pellet, touching_dot) do
-        touching_power_pellet or touching_dot
+      def score?(touching_power_pellet?, touching_dot?) do
+        touching_power_pellet? or touching_dot?
       end
 
-      def lose?(power_pellet_active, touching_ghost) do
-        not power_pellet_active and touching_ghost
+      def lose?(power_pellet_active?, touching_ghost?) do
+        not power_pellet_active? and touching_ghost?
       end
 
-      def win?(has_eaten_all_dots, power_pellet_active, touching_ghost) do
-        has_eaten_all_dots and not lose?(power_pellet_active, touching_ghost)
+      def win?(has_eaten_all_dots?, power_pellet_active?, touching_ghost?) do
+        has_eaten_all_dots? and not lose?(power_pellet_active?, touching_ghost?)
       end
     end
   end
@@ -28,22 +28,22 @@ defmodule ElixirAnalyzer.ExerciseTest.PacmanRulesTest do
       comments_include: [Constants.pacman_rules_use_strictly_boolean_operators()] do
       [
         defmodule Rules do
-          def eat_ghost?(power_pellet_active, touching_ghost) do
-            power_pellet_active && touching_ghost
+          def eat_ghost?(power_pellet_active?, touching_ghost?) do
+            power_pellet_active? && touching_ghost?
           end
         end,
         defmodule Rules do
-          def eat_ghost?(power_pellet_active, touching_ghost) do
-            power_pellet_active and touching_ghost
+          def eat_ghost?(power_pellet_active?, touching_ghost?) do
+            power_pellet_active? and touching_ghost?
           end
 
-          def lose?(power_pellet_active, touching_ghost) do
-            not power_pellet_active && touching_ghost
+          def lose?(power_pellet_active?, touching_ghost?) do
+            not power_pellet_active? && touching_ghost?
           end
         end,
         defmodule Rules do
-          def eat_ghost?(power_pellet_active, touching_ghost) do
-            Kernel.&&(power_pellet_active, touching_ghost)
+          def eat_ghost?(power_pellet_active?, touching_ghost?) do
+            Kernel.&&(power_pellet_active?, touching_ghost?)
           end
         end
       ]
@@ -53,13 +53,13 @@ defmodule ElixirAnalyzer.ExerciseTest.PacmanRulesTest do
       comments_include: [Constants.pacman_rules_use_strictly_boolean_operators()] do
       [
         defmodule Rules do
-          def score?(touching_power_pellet, touching_dot) do
-            touching_power_pellet || touching_dot
+          def score?(touching_power_pellet?, touching_dot?) do
+            touching_power_pellet? || touching_dot?
           end
         end,
         defmodule Rules do
-          def score?(touching_power_pellet, touching_dot) do
-            Kernel.||(touching_power_pellet, touching_dot)
+          def score?(touching_power_pellet?, touching_dot?) do
+            Kernel.||(touching_power_pellet?, touching_dot?)
           end
         end
       ]
@@ -69,32 +69,32 @@ defmodule ElixirAnalyzer.ExerciseTest.PacmanRulesTest do
       comments_include: [Constants.pacman_rules_use_strictly_boolean_operators()] do
       [
         defmodule Rules do
-          def lose?(power_pellet_active, touching_ghost) do
-            !power_pellet_active and touching_ghost
+          def lose?(power_pellet_active?, touching_ghost?) do
+            !power_pellet_active? and touching_ghost?
           end
         end,
         defmodule Rules do
-          def lose?(power_pellet_active, touching_ghost) do
-            touching_ghost and !power_pellet_active
+          def lose?(power_pellet_active?, touching_ghost?) do
+            touching_ghost? and !power_pellet_active?
           end
         end,
         defmodule Rules do
-          def lose?(power_pellet_active, touching_ghost) do
-            not power_pellet_active and touching_ghost
+          def lose?(power_pellet_active?, touching_ghost?) do
+            not power_pellet_active? and touching_ghost?
           end
 
-          def win?(has_eaten_all_dots, power_pellet_active, touching_ghost) do
-            has_eaten_all_dots and !lose?(power_pellet_active, touching_ghost)
+          def win?(has_eaten_all_dots?, power_pellet_active?, touching_ghost?) do
+            has_eaten_all_dots? and !lose?(power_pellet_active?, touching_ghost?)
           end
         end,
         defmodule Rules do
-          def eat_ghost?(power_pellet_active, touching_ghost) do
-            !!power_pellet_active and !!touching_ghost
+          def eat_ghost?(power_pellet_active?, touching_ghost?) do
+            !!power_pellet_active? and !!touching_ghost?
           end
         end,
         defmodule Rules do
-          def lose?(power_pellet_active, touching_ghost) do
-            Kernel.!(power_pellet_active) and touching_ghost
+          def lose?(power_pellet_active?, touching_ghost?) do
+            Kernel.!(power_pellet_active?) and touching_ghost?
           end
         end
       ]


### PR DESCRIPTION
Resolves https://github.com/exercism/elixir-analyzer/issues/384

The check is relaxed - now just one usage of `?ß`, `?ä`, `?ö`, `?ü`, `?_`, `?a`, or `?z` in the solution is enough, as long as the corresponding integer literals aren't found.

A trade-off: this will produce false-positives in scenarios in which people randomly include one of those numbers in the code, including in comments, e.g. `?ß # 223`