### PR TITLE
Extend common checks to also look for `dbg` calls

### DIFF
--- a/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
+++ b/lib/elixir_analyzer/exercise_test/common_checks/debug_functions.ex
@@ -12,6 +12,12 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecks.DebugFunctions do
         comment Constants.solution_debug_functions()
         called_fn module: IO, name: :inspect
       end
+
+      assert_no_call Constants.solution_debug_functions() do
+        type :informative
+        comment Constants.solution_debug_functions()
+        called_fn module: Kernel, name: :dbg
+      end
     end
   end
 end

--- a/test/elixir_analyzer/exercise_test/common_checks_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks_test.exs
@@ -282,13 +282,6 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecksTest do
           def foo(name) do
             Debug.dbg(name)
           end
-        end,
-        defmodule MyModule do
-          import Kernel, only: [dbg: 1]
-
-          def foo(name) do
-            dbg(name)
-          end
         end
       ]
     end

--- a/test/elixir_analyzer/exercise_test/common_checks_test.exs
+++ b/test/elixir_analyzer/exercise_test/common_checks_test.exs
@@ -266,6 +266,32 @@ defmodule ElixirAnalyzer.ExerciseTest.CommonChecksTest do
         end
       ]
     end
+
+    test_exercise_analysis "reports Kernel.dbg",
+      comments: [Constants.solution_debug_functions()] do
+      [
+        defmodule MyModule do
+          def foo() do
+            (1 + 1)
+            |> dbg()
+          end
+        end,
+        defmodule MyModule do
+          alias Kernel, as: Debug
+
+          def foo(name) do
+            Debug.dbg(name)
+          end
+        end,
+        defmodule MyModule do
+          import Kernel, only: [dbg: 1]
+
+          def foo(name) do
+            dbg(name)
+          end
+        end
+      ]
+    end
   end
 
   describe "boilerplate and TODO comments" do


### PR DESCRIPTION
Part of https://github.com/exercism/elixir-analyzer/issues/368

The changes add `Kernel.dbg` to the list of checked functions