### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/elixir_test.yml
+++ b/.github/workflows/elixir_test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: hexpm/elixir:1.15.2-erlang-26.0.2-debian-bookworm-20230612
@@ -65,7 +65,7 @@ jobs:
         run: mix dialyzer
 
   smoke-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir_test_external.yml
+++ b/.github/workflows/elixir_test_external.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     container:
       image: hexpm/elixir:1.15.2-erlang-26.0.2-debian-bookworm-20230612


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.